### PR TITLE
MAINT: Add vocab exception

### DIFF
--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -32,6 +32,7 @@ FE-BI
 getters
 globals
 [Gg]gRPC
+hist
 HFSS
 Huray
 Icepak


### PR DESCRIPTION
Fixes false positive from codespell.

Closes #29
Related to codespell#2185 and codespell#1147