### PR TITLE
BUILD: Update doc dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ doc = [
     "jupytext==1.16.1",
     "matplotlib==3.8.3",
     "nbsphinx==0.9.3",
+    "nbconvert < 7.14",
     "numpydoc==1.6.0",
     "osmnx",
     "pytest-sphinx==0.6.0",


### PR DESCRIPTION
This should fix the issue related to flushed values, see #107.
The issue seems to be related to `nbsphinx` which uses a version of `nbconvert` that might trigger the problem.
FYI, when running an example with flushed values you would end up with HTML files containing

```
</pre>
....
end{sphinxVerbatim}
```

and the PDF file would fail. The work around consists in pinning versions of `nbconvert`.

See:
- https://github.com/spatialaudio/nbsphinx/issues/776
- https://github.com/jupyter/nbconvert/issues/2092