### PR TITLE
CI: Add job dedicated to doc deploy

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -101,9 +101,14 @@ jobs:
           path: doc/_build/latex
           retention-days: 7
 
-      - name: Deploy
-        if: contains(github.ref, 'refs/heads/main')
-        uses: ansys/actions/doc-deploy-dev@v4
+  deploy-doc:
+    name: Upload documentation
+    if: contains(github.ref, 'refs/heads/main')
+    runs-on: ubuntu-latest
+    needs: [doc-build]
+    steps:
+      - name: Deploy the documentation
+        uses: ansys/actions/doc-deploy-stable@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As title says.

The problem was discovered in the latest commit in main where the deploy step (included in doc build) failed because the step was performed in windows VM while the action should be used in Linux os.

![image](https://github.com/user-attachments/assets/b77474da-62da-40f4-8558-bcd799eacd2e)
