### PR TITLE
CICD: Leverage error redirection in log

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -70,11 +70,13 @@ jobs:
           SPHINXBUILD_KEEP_DOCTREEDIR: "1"
         run: |
           .venv\Scripts\Activate.ps1
-          . .\doc\make.bat html 6>&1 2>&1 | Tee-Object -Variable output
 
-          # Check sphinx-build exit code and error messages
-          if ($LASTEXITCODE -ne 0 -or $output -match 'CellExecutionError') {
-            Write-Error "HTML build failed, stopping the workflow."
+          # NOTE: The error redirection is leveraged to make sphinx exit with non null value on CellExecutionError.
+          . .\doc\make.bat html -j auto --color 2> sphinx-build_error.log
+
+          $error_log = Get-Content sphinx-build_error.log
+          if ($error_log -match 'CellExecutionError') {
+            Write-Error "Sphinx build failed with cell execution Error."
             exit 1
           }
 

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -5,7 +5,7 @@ pushd %~dp0
 REM Command file for Sphinx documentation
 
 if "%SPHINXOPTS%" == "" (
-	set SPHINXOPTS=-j auto --color -W
+	set SPHINXOPTS=-j auto --color
 )
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build


### PR DESCRIPTION
There was an issue with the previous way of doing things as errors are redirected to the standard output and gets wrongly processed by powershell. This should do the trick.