### PR TITLE
CI: Fix deploy-doc by using ansys actions v5

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -111,7 +111,7 @@ jobs:
     needs: [doc-build]
     steps:
       - name: Deploy the documentation
-        uses: ansys/actions/doc-deploy-dev@v4
+        uses: ansys/actions/doc-deploy-dev@v5
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We upload the documentation with `actions/upload-artifact@v4` but `ansys/actions/doc-deploy@v4` was using `actions/download-artifact@v3` which is not compatible with the uploaded file. Bumping to `ansys/actionsdoc-deploy@v5` should handle this.