### PR TITLE
BUILD: Update requirements to fix rendering

### DIFF
--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -2,8 +2,8 @@
 git+https://github.com/ansys/pyaedt@main
 
 # Examples dependencies
-imageio==2.34.0
-matplotlib==3.8.0
+imageio==2.34.2
+matplotlib==3.9.2
 numpy==1.26.4
 openpyxl==3.1.4
 osmnx==1.9.0
@@ -14,15 +14,15 @@ joblib==1.4.0
 # Never directly imported but required when loading ML related file
 # See https://github.com/ansys/pyaedt/pull/4713
 scikit-learn==1.5.0
-scikit-rf==1.1.0
+scikit-rf==1.2.0
 SRTM.py
 utm
 
 # Documentation dependencies
 ansys-sphinx-theme==0.16.6
-ipython==8.25.0
-jupyterlab==4.2.0
-nbsphinx==0.9.0
+ipython==8.26.0
+jupyterlab==4.2.4
+nbsphinx==0.9.5
 numpydoc==1.7.0
 pypandoc==1.13.0
 recommonmark
@@ -32,7 +32,7 @@ sphinx-autodoc-typehints==2.0.0
 sphinx-copybutton==0.5.2
 sphinx-gallery==0.16.0
 sphinx-notfound-page==1.0.0
-sphinx_design==0.6.0
+sphinx_design==0.6.1
 sphinxcontrib-websupport==1.2.7
-jupytext==1.16.1
-nbconvert==7.13.0
+jupytext==1.16.4
+nbconvert==7.16.4


### PR DESCRIPTION
This is the first update about the requirements. On top of upgrading the packages version, it should fix the problem we have currently with the example rendering where we see the content of the examples for no reason.

Closes #206 