### PR TITLE
DOCS: Update links after OSS

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,8 +3,8 @@ Examples
 
 **Useful links**:
 `Installation <https://aedt.docs.pyansys.com/version/stable/Getting_started/Installation.html>`_ |
-`Source repository <https://github.com/ansys-internal/pyaedt-examples>`_ |
-`Issues <https://github.com/ansys-internal/pyaedt-examples/issues>`_
+`Source repository <https://github.com/ansys/pyaedt-examples>`_ |
+`Issues <https://github.com/ansys/pyaedt-examples/issues>`_
 
 This repository contains end-to-end embedding examples that demonstrate how to use
 `PyAEDT <https://aedt.docs.pyansys.com/version/stable/>`_.


### PR DESCRIPTION
The repo moving into public, we need to update the links to the other organization.