### PR TITLE
CHORE: Update dependencies and add pyedb example back

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -290,8 +290,6 @@ def convert_examples_into_notebooks(app):
         "interference.py",
         "hfss_emit.py",
         "component_conversion.py",
-        # FIXME: Temporary skipped due to PyEDB v0.43.0, see https://github.com/ansys/pyedb/issues/1162
-        "dcir_hfss.py",
     )
 
     unchanged_examples = []

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,5 +1,5 @@
 # PyAEDT dependency
-https://github.com/ansys/pyaedt/archive/refs/heads/main.zip
+pyaedt[graphics] @ git+https://github.com/ansys/pyaedt@main
 
 # Examples dependencies
 imageio==2.37.0


### PR DESCRIPTION
## Description
As title says. Use `pyaedt[graphics]` and allow the skipped `pyedb` example to me run again.

## Issue linked
None

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
