### PR TITLE
CI: Do not download PyAEDT all history

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -72,10 +72,25 @@ jobs:
           python -m pip install wheel setuptools -U
           python -c "import sys; print(sys.executable)"
 
-      - name: Install project and documentation dependencies
+      - name: Install project and documentation dependencies without PyAEDT
         run: |
           .venv\Scripts\Activate.ps1
-          pip install --no-cache-dir -r requirements/requirements_doc.txt
+          # Exclude pyaedt from the dependencies to avoid downloading the whole repository history
+          # Related to https://github.com/pypa/pip/issues/2432
+          grep -v '^pyaedt\[graphics\] @ git+' requirements/requirements_doc.txt > requirements/filterd_requirements_doc.txt
+          pip install --no-cache-dir -r requirements/filterd_requirements_doc.txt
+
+      - name: Clone PyAEDT on main branch
+        uses: actions/checkout@v4
+        with:
+          repository: ansys/pyaedt
+          path: "external/pyaedt"
+          ref: "main"
+
+      - name: Install PyAEDT main branch version with its test dependencies
+        run: |
+          . .venv\Scripts\Activate.ps1
+          pip install --no-cache-dir external/pyaedt[graphics]
 
       # Use environment variable speed up build for PDF pages
       - name: Create HTML documentation


### PR DESCRIPTION
## Description
PyAEDT is a large project and it's even worse if you try to download it with the full history. This is the common behavior if you work with the `requirements_doc.txt` file. The PR consist in avoid that by only downloading with depth 1 (default behavior of actions/checkout).

## Issue linked
None

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
