### PR TITLE
DOCS: Pin vtk-osmesa version

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -23,7 +23,7 @@ help:
 		@echo "Removing vtk to avoid conflicts with vtk-osmesa needed for CI/CD"; \
 		pip uninstall --yes vtk; \
 		@echo "Installing vtk-osmesa"; \
-		pip install --extra-index-url https://wheels.vtk.org vtk-osmesa; \
+		pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.3.1; \
 	fi
 	@if [ "${ON_CI}" = "True" ] && [ "$$is_pypandoc_binary_installed" != "yes" ]; then \
 		@echo "Removing pypandoc to avoid conflicts with pypandoc-binary needed for CI/CD"; \

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -25,7 +25,7 @@ if NOT "%is_vtk_osmesa_installed%" == "vtk-osmesa" if "%ON_CI%" == "true" (
 	@ECHO ON
 	echo "Installing vtk-osmesa"
 	@ECHO OFF
-	pip install --extra-index-url https://wheels.vtk.org vtk-osmesa)
+	pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.3.1)
 for /f %%i in ('pip freeze ^| findstr /c:"pypandoc_binary"') do set is_pypandoc_binary_installed=%%i
 if NOT "%is_pypandoc_binary_installed%" == "pypandoc_binary" if "%ON_CI%" == "true" (
 	@ECHO ON


### PR DESCRIPTION
## Description
As title says. Avoid using non pinned version of `vtk-osmesa` to prevent supply chain attack.

## Issue linked
None

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
