### PR TITLE
CI: Use AEDT 25R2

### DIFF
--- a/examples/00_edb/legacy_standalone/GDS_workflow.py
+++ b/examples/00_edb/legacy_standalone/GDS_workflow.py
@@ -23,7 +23,7 @@ from ansys.aedt.core.hfss3dlayout import  Hfss3dLayout
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ### Create temporary directory

--- a/examples/00_edb/legacy_standalone/Plot_nets.py
+++ b/examples/00_edb/legacy_standalone/Plot_nets.py
@@ -27,7 +27,7 @@ targetfolder = download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_dir.name)
 
 # +
 # Select EDB version (change it manually if needed, e.g. "2025.1")
-edb_version = "2025.1"
+edb_version = "2025.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=targetfolder, edbversion=edb_version)

--- a/examples/00_edb/legacy_standalone/differential_vias.py
+++ b/examples/00_edb/legacy_standalone/differential_vias.py
@@ -21,7 +21,7 @@ import pyedb
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 temp_folder = tempfile.TemporaryDirectory(suffix=".ansys")

--- a/examples/00_edb/legacy_standalone/edb_to_ipc2581.py
+++ b/examples/00_edb/legacy_standalone/edb_to_ipc2581.py
@@ -27,7 +27,7 @@ print(targetfile)
 
 # +
 # Select EDB version (change it manually if needed, e.g. "2025.1")
-edb_version = "2025.1"
+edb_version = "2025.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=targetfile, edbversion=edb_version)

--- a/examples/00_edb/legacy_standalone/siwave_dcir.py
+++ b/examples/00_edb/legacy_standalone/siwave_dcir.py
@@ -34,7 +34,7 @@ if os.path.exists(aedt_file):
     os.remove(aedt_file)
 
 # Select EDB version (change it manually if needed, e.g. "2025.1")
-edb_version = "2025.1"
+edb_version = "2025.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=targetfile, edbversion=edb_version)

--- a/examples/00_edb/use_configuration/dcir.py
+++ b/examples/00_edb/use_configuration/dcir.py
@@ -16,7 +16,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 

--- a/examples/00_edb/use_configuration/import_components.py
+++ b/examples/00_edb/use_configuration/import_components.py
@@ -23,7 +23,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 
 # Download the example PCB data.
 

--- a/examples/00_edb/use_configuration/import_material.py
+++ b/examples/00_edb/use_configuration/import_material.py
@@ -20,7 +20,7 @@ from pyedb import Edb
 
 # Define constants
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 
 # ## Preparation
 

--- a/examples/00_edb/use_configuration/import_operations.py
+++ b/examples/00_edb/use_configuration/import_operations.py
@@ -18,7 +18,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 from pyedb import Edb
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # -

--- a/examples/00_edb/use_configuration/import_padstack_definitions.py
+++ b/examples/00_edb/use_configuration/import_padstack_definitions.py
@@ -24,7 +24,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 
 # Download the example PCB data.
 

--- a/examples/00_edb/use_configuration/import_ports.py
+++ b/examples/00_edb/use_configuration/import_ports.py
@@ -28,7 +28,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # Download the example PCB data.

--- a/examples/00_edb/use_configuration/import_setup_ac.py
+++ b/examples/00_edb/use_configuration/import_setup_ac.py
@@ -22,7 +22,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # Download the example PCB data.

--- a/examples/00_edb/use_configuration/import_sources.py
+++ b/examples/00_edb/use_configuration/import_sources.py
@@ -27,7 +27,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # Download the example PCB data.

--- a/examples/00_edb/use_configuration/import_stackup.py
+++ b/examples/00_edb/use_configuration/import_stackup.py
@@ -19,7 +19,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # Download the example PCB data.

--- a/examples/00_edb/use_configuration/pcb_dc_ir.py
+++ b/examples/00_edb/use_configuration/pcb_dc_ir.py
@@ -18,7 +18,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # Download the example PCB data.

--- a/examples/00_edb/use_configuration/pdn_analysis.py
+++ b/examples/00_edb/use_configuration/pdn_analysis.py
@@ -18,7 +18,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # Download the example PCB data.

--- a/examples/00_edb/use_configuration/post_layout_parametrize.py
+++ b/examples/00_edb/use_configuration/post_layout_parametrize.py
@@ -29,7 +29,7 @@ target_aedb = download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_dir.name)
 print("Project is located in ", target_aedb)
 
 # Select EDB version (change it manually if needed, e.g. "2025.1")
-edb_version = "2025.1"
+edb_version = "2025.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=target_aedb, edbversion=edb_version)

--- a/examples/00_edb/use_configuration/serdes.py
+++ b/examples/00_edb/use_configuration/serdes.py
@@ -16,7 +16,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # Download the example PCB data.

--- a/examples/aedt_general/components/component_conversion.py
+++ b/examples/aedt_general/components/component_conversion.py
@@ -32,7 +32,7 @@ from ansys.aedt.core.examples.downloads import download_file
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 OLD_AEDT_VERSION = "2024.1"
 NG_MODE = False  # Open AEDT UI when AEDT is launched.
 

--- a/examples/aedt_general/components/reuse_component.py
+++ b/examples/aedt_general/components/reuse_component.py
@@ -25,7 +25,7 @@ from ansys.aedt.core import Hfss
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ### Create temporary directory

--- a/examples/aedt_general/configuration_files.py
+++ b/examples/aedt_general/configuration_files.py
@@ -39,7 +39,7 @@ from ansys.aedt.core.examples.downloads import download_icepak
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/aedt_general/modeler/circuit_schematic.py
+++ b/examples/aedt_general/modeler/circuit_schematic.py
@@ -21,7 +21,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/aedt_general/modeler/coordinate_system.py
+++ b/examples/aedt_general/modeler/coordinate_system.py
@@ -17,7 +17,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open the AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/aedt_general/modeler/netlist_to_schematic.py
+++ b/examples/aedt_general/modeler/netlist_to_schematic.py
@@ -22,7 +22,7 @@ from ansys.aedt.core.examples.downloads import download_netlist
 
 # ## Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/aedt_general/modeler/polyline.py
+++ b/examples/aedt_general/modeler/polyline.py
@@ -17,7 +17,7 @@ import ansys.aedt.core
 
 # Define constants
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 

--- a/examples/aedt_general/optimetrics.py
+++ b/examples/aedt_general/optimetrics.py
@@ -18,7 +18,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/aedt_general/report/automatic_report.py
+++ b/examples/aedt_general/report/automatic_report.py
@@ -23,7 +23,7 @@ from IPython.display import Image
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/aedt_general/report/virtual_compliance.py
+++ b/examples/aedt_general/report/virtual_compliance.py
@@ -21,7 +21,7 @@ from ansys.aedt.core.visualization.post.compliance import VirtualCompliance
 
 # ## Define constants
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/electrothermal/coaxial_hfss_icepak.py
+++ b/examples/electrothermal/coaxial_hfss_icepak.py
@@ -20,7 +20,7 @@ from ansys.aedt.core.visualization.plot.pdf import AnsysReport
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/electrothermal/component_3d.py
+++ b/examples/electrothermal/component_3d.py
@@ -18,7 +18,7 @@ from ansys.aedt.core.examples.downloads import download_icepak_3d_component
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory and download files

--- a/examples/electrothermal/components_csv.py
+++ b/examples/electrothermal/components_csv.py
@@ -26,7 +26,7 @@ from matplotlib import pyplot as plt
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Download and open project

--- a/examples/electrothermal/ecad_import.py
+++ b/examples/electrothermal/ecad_import.py
@@ -19,7 +19,7 @@ from ansys.aedt.core import Hfss3dLayout, Icepak
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Open project

--- a/examples/electrothermal/electrothermal.py
+++ b/examples/electrothermal/electrothermal.py
@@ -31,7 +31,7 @@ from pyedb import Edb, Siwave
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = True  # Open AEDT UI when it is launched.
 

--- a/examples/electrothermal/graphic_card.py
+++ b/examples/electrothermal/graphic_card.py
@@ -24,7 +24,7 @@ from IPython.display import Image
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Do not show the graphical user interface.
 

--- a/examples/electrothermal/icepak_circuit_hfss_coupling.py
+++ b/examples/electrothermal/icepak_circuit_hfss_coupling.py
@@ -52,7 +52,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/electrothermal/sherlock.py
+++ b/examples/electrothermal/sherlock.py
@@ -20,7 +20,7 @@ from ansys.aedt.core.examples.downloads import download_sherlock
 
 # Define constants
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/antenna/5G_antenna_parametrics.py
+++ b/examples/high_frequency/antenna/5G_antenna_parametrics.py
@@ -84,7 +84,7 @@ temp_dir = tempfile.TemporaryDirectory(suffix=".ansys")
 aedb_path = os.path.join(temp_dir.name, "linear_array.aedb")
 
 # Select EDB version (change it manually if needed, e.g. "2025.1")
-edb_version = "2025.1"
+edb_version = "2025.2"
 print(f"EDB version: {edb_version}")
 
 # Create an instance of the Edb class.
@@ -242,7 +242,7 @@ print("EDB saved correctly to {}. You can import in AEDT.".format(aedb_path))
 h3d = ansys.aedt.core.Hfss(
     projectname="Demo_3DComp",
     designname="Linear_Array",
-    specified_version="2025.1",
+    specified_version="2025.2",
     new_desktop_session=True,
     non_graphical=non_graphical,
     close_on_exit=True,

--- a/examples/high_frequency/antenna/array.py
+++ b/examples/high_frequency/antenna/array.py
@@ -27,7 +27,7 @@ from ansys.aedt.core.generic import file_utils
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/antenna/dipole.py
+++ b/examples/high_frequency/antenna/dipole.py
@@ -22,7 +22,7 @@ from ansys.aedt.core import Hfss
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/antenna/fss_unitcell.py
+++ b/examples/high_frequency/antenna/fss_unitcell.py
@@ -20,7 +20,7 @@ from ansys.aedt.core.examples.downloads import download_file
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ### Create temporary directory

--- a/examples/high_frequency/antenna/interferences/antenna.py
+++ b/examples/high_frequency/antenna/interferences/antenna.py
@@ -20,7 +20,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/high_frequency/antenna/interferences/hfss_emit.py
+++ b/examples/high_frequency/antenna/interferences/hfss_emit.py
@@ -27,7 +27,7 @@ from ansys.aedt.core.emit_core.emit_constants import ResultType, TxRxMode
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/high_frequency/antenna/interferences/interference.py
+++ b/examples/high_frequency/antenna/interferences/interference.py
@@ -20,7 +20,7 @@ from ansys.aedt.core.emit_core.emit_constants import InterfererType
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/high_frequency/antenna/interferences/interference_type.py
+++ b/examples/high_frequency/antenna/interferences/interference_type.py
@@ -27,7 +27,7 @@ from PySide6 import QtCore, QtGui, QtUiTools, QtWidgets
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # Uncomment the following code if there are Qt plugin errors

--- a/examples/high_frequency/antenna/interferences/protection.py
+++ b/examples/high_frequency/antenna/interferences/protection.py
@@ -25,7 +25,7 @@ from ansys.aedt.core import Emit
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/high_frequency/antenna/large_scenarios/city.py
+++ b/examples/high_frequency/antenna/large_scenarios/city.py
@@ -20,7 +20,7 @@ import ansys.aedt.core
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ### Create temporary directory

--- a/examples/high_frequency/antenna/large_scenarios/doppler.py
+++ b/examples/high_frequency/antenna/large_scenarios/doppler.py
@@ -22,7 +22,7 @@ from ansys.aedt.core.examples.downloads import unzip
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/antenna/large_scenarios/reflector.py
+++ b/examples/high_frequency/antenna/large_scenarios/reflector.py
@@ -20,7 +20,7 @@ from ansys.aedt.core.examples.downloads import download_sbr
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/antenna/large_scenarios/time_domain.py
+++ b/examples/high_frequency/antenna/large_scenarios/time_domain.py
@@ -20,7 +20,7 @@ from ansys.aedt.core.examples.downloads import download_sbr_time
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/antenna/patch.py
+++ b/examples/high_frequency/antenna/patch.py
@@ -29,7 +29,7 @@ from ansys.aedt.core.modeler.advanced_cad.stackup_3d import Stackup3D
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/emc/armoured_cable.py
+++ b/examples/high_frequency/emc/armoured_cable.py
@@ -26,7 +26,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/high_frequency/emc/busbar.py
+++ b/examples/high_frequency/emc/busbar.py
@@ -19,7 +19,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False
 

--- a/examples/high_frequency/emc/choke.py
+++ b/examples/high_frequency/emc/choke.py
@@ -19,7 +19,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/high_frequency/emc/double_pulse_test.py
+++ b/examples/high_frequency/emc/double_pulse_test.py
@@ -24,7 +24,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/emc/eigenmode.py
+++ b/examples/high_frequency/emc/eigenmode.py
@@ -42,7 +42,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/emc/flex_cable.py
+++ b/examples/high_frequency/emc/flex_cable.py
@@ -20,7 +20,7 @@ from ansys.aedt.core.generic.file_utils import generate_unique_name
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 
 # ## Set non-graphical mode
 #

--- a/examples/high_frequency/emc/subcircuit.py
+++ b/examples/high_frequency/emc/subcircuit.py
@@ -20,7 +20,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/high_frequency/layout/gui_manipulation.py
+++ b/examples/high_frequency/layout/gui_manipulation.py
@@ -19,7 +19,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = True  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/layout/power_integrity/ac_q3d.py
+++ b/examples/high_frequency/layout/power_integrity/ac_q3d.py
@@ -21,7 +21,7 @@ import pyedb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/layout/power_integrity/dcir_hfss.py
+++ b/examples/high_frequency/layout/power_integrity/dcir_hfss.py
@@ -33,7 +33,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/layout/power_integrity/dcir_q3d.py
+++ b/examples/high_frequency/layout/power_integrity/dcir_q3d.py
@@ -21,7 +21,7 @@ import pyedb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False
 

--- a/examples/high_frequency/layout/power_integrity/power_integrity.py
+++ b/examples/high_frequency/layout/power_integrity/power_integrity.py
@@ -32,7 +32,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/layout/signal_integrity/ami.py
+++ b/examples/high_frequency/layout/signal_integrity/ami.py
@@ -24,7 +24,7 @@ from matplotlib import pyplot as plt
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory and download example files

--- a/examples/high_frequency/layout/signal_integrity/circuit_transient.py
+++ b/examples/high_frequency/layout/signal_integrity/circuit_transient.py
@@ -21,7 +21,7 @@ from matplotlib import pyplot as plt
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/high_frequency/layout/signal_integrity/multizone.py
+++ b/examples/high_frequency/layout/signal_integrity/multizone.py
@@ -20,7 +20,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-EDB_VERSION = "2025.1"
+EDB_VERSION = "2025.2"
 
 # ## Create temporary directory
 #

--- a/examples/high_frequency/layout/signal_integrity/pre_layout.py
+++ b/examples/high_frequency/layout/signal_integrity/pre_layout.py
@@ -41,7 +41,7 @@ from pyedb import Edb
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/layout/signal_integrity/pre_layout_parametrized.py
+++ b/examples/high_frequency/layout/signal_integrity/pre_layout_parametrized.py
@@ -24,7 +24,7 @@ from pyedb import Edb
 
 # ## Define constants
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/layout/signal_integrity/serdes_differential.py
+++ b/examples/high_frequency/layout/signal_integrity/serdes_differential.py
@@ -30,7 +30,7 @@ print("Project folder is", target_aedb)
 
 # +
 # Select EDB version (change it manually if needed, e.g. "2025.1")
-edb_version = "2025.1"
+edb_version = "2025.2"
 print(f"EDB version: {edb_version}")
 
 edbapp = pyedb.Edb(target_aedb, edbversion=edb_version)

--- a/examples/high_frequency/multiphysics/hfss_mechanical.py
+++ b/examples/high_frequency/multiphysics/hfss_mechanical.py
@@ -19,7 +19,7 @@ from ansys.aedt.core.examples.downloads import download_via_wizard
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/multiphysics/microwave_oven.py
+++ b/examples/high_frequency/multiphysics/microwave_oven.py
@@ -28,7 +28,7 @@ from ansys.aedt.core.visualization.plot.pdf import AnsysReport
 #
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/multiphysics/mri.py
+++ b/examples/high_frequency/multiphysics/mri.py
@@ -32,7 +32,7 @@ from ansys.aedt.core.examples import downloads
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/radiofrequency_mmwave/coplanar_waveguide.py
+++ b/examples/high_frequency/radiofrequency_mmwave/coplanar_waveguide.py
@@ -20,7 +20,7 @@ import ansys.aedt.core
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Run the example without opening the UI.
 

--- a/examples/high_frequency/radiofrequency_mmwave/iris_filter.py
+++ b/examples/high_frequency/radiofrequency_mmwave/iris_filter.py
@@ -22,7 +22,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/radiofrequency_mmwave/lumped_element.py
+++ b/examples/high_frequency/radiofrequency_mmwave/lumped_element.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 
 # ## Define function used for plotting
 #

--- a/examples/high_frequency/radiofrequency_mmwave/spiral.py
+++ b/examples/high_frequency/radiofrequency_mmwave/spiral.py
@@ -18,7 +18,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/high_frequency/radiofrequency_mmwave/stripline.py
+++ b/examples/high_frequency/radiofrequency_mmwave/stripline.py
@@ -19,7 +19,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 
 
@@ -34,7 +34,7 @@ temp_folder = tempfile.TemporaryDirectory(suffix=".ansys")
 
 # ## Launch AEDT and 2D Extractor
 #
-# Launch AEDT 2025.1 in graphical mode and launch 2D Extractor. This example
+# Launch AEDT 2025.2 in graphical mode and launch 2D Extractor. This example
 # uses SI units.
 
 q2d = ansys.aedt.core.Q2d(

--- a/examples/low_frequency/general/control_program.py
+++ b/examples/low_frequency/general/control_program.py
@@ -21,7 +21,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/dc_analysis.py
+++ b/examples/low_frequency/general/dc_analysis.py
@@ -19,7 +19,7 @@ from ansys.aedt.core import Maxwell3d
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/eddy_current.py
+++ b/examples/low_frequency/general/eddy_current.py
@@ -19,7 +19,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/electrostatic.py
+++ b/examples/low_frequency/general/electrostatic.py
@@ -22,7 +22,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False
 

--- a/examples/low_frequency/general/external_circuit.py
+++ b/examples/low_frequency/general/external_circuit.py
@@ -16,7 +16,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/field_export.py
+++ b/examples/low_frequency/general/field_export.py
@@ -21,7 +21,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/resistance.py
+++ b/examples/low_frequency/general/resistance.py
@@ -21,7 +21,7 @@ from ansys.aedt.core.visualization.plot.pdf import AnsysReport
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 NUM_CORES = 4
 

--- a/examples/low_frequency/general/twin_builder/dynamic_rom.py
+++ b/examples/low_frequency/general/twin_builder/dynamic_rom.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/twin_builder/lti_rom_sml.py
+++ b/examples/low_frequency/general/twin_builder/lti_rom_sml.py
@@ -24,7 +24,7 @@ from ansys.aedt.core.application.variables import CSVDataset
 
 # Define constants
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/twin_builder/rc_circuit.py
+++ b/examples/low_frequency/general/twin_builder/rc_circuit.py
@@ -19,7 +19,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/twin_builder/rectifier.py
+++ b/examples/low_frequency/general/twin_builder/rectifier.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/general/twin_builder/static_rom.py
+++ b/examples/low_frequency/general/twin_builder/static_rom.py
@@ -23,7 +23,7 @@ from ansys.aedt.core.examples import downloads
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/magnetic/2d-axi_magnetostatic_actuator.py
+++ b/examples/low_frequency/magnetic/2d-axi_magnetostatic_actuator.py
@@ -22,7 +22,7 @@ import ansys.aedt.core  # Interface to Ansys Electronics Desktop
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/magnetic/3d_magsta_rotational_actuator.py
+++ b/examples/low_frequency/magnetic/3d_magsta_rotational_actuator.py
@@ -25,7 +25,7 @@ import ansys.aedt.core  # Interface to Ansys Electronics Desktop
 
 # ### Define constants
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/magnetic/choke.py
+++ b/examples/low_frequency/magnetic/choke.py
@@ -19,7 +19,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 

--- a/examples/low_frequency/magnetic/lorentz_actuator.py
+++ b/examples/low_frequency/magnetic/lorentz_actuator.py
@@ -19,7 +19,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/magnetic/magneto_motive_line.py
+++ b/examples/low_frequency/magnetic/magneto_motive_line.py
@@ -27,7 +27,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/magnetic/transient_winding.py
+++ b/examples/low_frequency/magnetic/transient_winding.py
@@ -32,7 +32,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/motor/aedt_motor/ipm_optimization.py
+++ b/examples/low_frequency/motor/aedt_motor/ipm_optimization.py
@@ -24,7 +24,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/motor/aedt_motor/magnet_segmentation.py
+++ b/examples/low_frequency/motor/aedt_motor/magnet_segmentation.py
@@ -19,7 +19,7 @@ from ansys.aedt.core.examples.downloads import download_file
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ## Create temporary directory

--- a/examples/low_frequency/motor/aedt_motor/pm_synchronous.py
+++ b/examples/low_frequency/motor/aedt_motor/pm_synchronous.py
@@ -22,7 +22,7 @@ from ansys.aedt.core.examples.downloads import download_leaf
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/motor/aedt_motor/rmxpert.py
+++ b/examples/low_frequency/motor/aedt_motor/rmxpert.py
@@ -22,7 +22,7 @@ import ansys.aedt.core
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/motor/aedt_motor/transformer.py
+++ b/examples/low_frequency/motor/aedt_motor/transformer.py
@@ -21,7 +21,7 @@ from ansys.aedt.core.generic.file_utils import read_csv_pandas
 
 # Define constants.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False
 
 # ## Create temporary directory

--- a/examples/low_frequency/motor/aedt_motor/transformer_inductance.py
+++ b/examples/low_frequency/motor/aedt_motor/transformer_inductance.py
@@ -20,7 +20,7 @@ from ansys.aedt.core import Maxwell2d
 
 # Define constants,
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/multiphysics/maxwell_icepak.py
+++ b/examples/low_frequency/multiphysics/maxwell_icepak.py
@@ -25,7 +25,7 @@ from ansys.aedt.core.generic.constants import AXIS
 #
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NG_MODE = False  # Open AEDT UI when it is launched.
 
 # ### Create temporary directory

--- a/examples/low_frequency/team_problem/asymmetric_conductor.py
+++ b/examples/low_frequency/team_problem/asymmetric_conductor.py
@@ -24,7 +24,7 @@ from ansys.aedt.core.generic.file_utils import write_csv
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/low_frequency/team_problem/bath_plate.py
+++ b/examples/low_frequency/team_problem/bath_plate.py
@@ -23,7 +23,7 @@ import ansys.aedt.core
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 

--- a/examples/template.py
+++ b/examples/template.py
@@ -25,7 +25,7 @@ import ansys.aedt.core  # Interface to Ansys Electronics Desktop
 # ### Define constants
 # Constants help ensure consistency and avoid repetition throughout the example.
 
-AEDT_VERSION = "2025.1"
+AEDT_VERSION = "2025.2"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 


### PR DESCRIPTION
## Description
Move examples from 25.1 to 25.2. If some things are not correctly working for pyedb we could chose between the following options:
1. Do not migrate pyedb examples to 25.2 and keep using 25.1
2. Do not run pyedb examples but use 25.2 in scripts

I would prefer the first approach as it would let us run the examples. However there is a need for an effort to migrate to 25.2 soon.

Pinging @svandenb-dev and @hui-zhou-a for visibility on the eventual problem.

## Issue linked
None

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
