### PR TITLE
FEAT: Add workflow to sync release tags from PyAEDT

### DIFF
--- a/.github/workflows/sync_release_tag.yml
+++ b/.github/workflows/sync_release_tag.yml
@@ -1,26 +1,52 @@
-name: Sync Release Tag From PyAEDT
+name: Sync release tag from PyAEDT
 
 on:
   repository_dispatch:
     types: [release_tag]
 
 jobs:
-  CreateTag:
+  create-tag:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-  
-      - name: Create and push tag
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Validate tag input
         run: |
           TAG_NAME="${{ github.event.client_payload.tag }}"
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "Tag $TAG_NAME already exists"
-          else
-            git tag "$TAG_NAME"
-            git push origin "$TAG_NAME"
+          if [[ -z "$TAG_NAME" ]]; then
+            echo "Error: No tag provided in the payload"
+            exit 1
           fi
+          echo "Tag to create: $TAG_NAME"
+
+      - name: Create and push tag
+        run: |
+          # Configure git username & email
+          git config --global user.name "${{ secrets.PYANSYS_CI_BOT_USERNAME }}"
+          git config --global user.email "${{ secrets.PYANSYS_CI_BOT_EMAIL }}"
+
+          TAG_NAME="${{ github.event.client_payload.tag }}"
+
+          if [[ -z "$TAG_NAME" ]]; then
+            echo "Error: No tag provided in the payload"
+            exit 1
+          fi
+          echo "Tag to create: $TAG_NAME"
+          
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Tag $TAG_NAME already exists, skipping creation"
+            exit 0
+          fi
+          
+          echo "Creating tag: $TAG_NAME"
+          git tag "$TAG_NAME"
+          
+          echo "Pushing tag to origin"
+          git push origin "$TAG_NAME"
+          
+          echo "Successfully created and pushed tag: $TAG_NAME"


### PR DESCRIPTION
## Description
Introduce a GitHub Actions workflow that creates and pushes release tags based on repository dispatch events. This ensures that tags are synchronized automatically when triggered.

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.

Introduce a GitHub Actions workflow that creates and pushes release tags based on repository dispatch events. This ensures that tags are synchronized automatically when triggered.