### PR TITLE
CI: Pin versions of actions in GitHub workflow files with SHA

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -42,7 +42,7 @@ jobs:
     name: Build documentation
     runs-on: [self-hosted, Windows, pyaedt-examples]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
           }
 
       - name: Upload HTML documentation artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: documentation-html
           path: doc/_build/html
@@ -121,7 +121,7 @@ jobs:
           . .\doc\make.bat pdf
 
       - name: Upload PDF documentation artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: documentation-pdf
           path: doc/_build/latex

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,7 +16,7 @@ jobs:
     name: Syncer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Suggest to add labels
-      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       # Execute only when no labels have been applied to the pull request
       if: toJSON(github.event.pull_request.labels.*.name) == '{}'
       with:

--- a/.github/workflows/sync_release_tag.yml
+++ b/.github/workflows/sync_release_tag.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository # zizmor: ignore[artipacked] , credentials must be persisted in this case
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
This PR updates the GitHub workflow files by pinning the versions of the actions used inside the jobs with their respective SHA.

This is a necessary step towards the introduction of the ``ansys/actions/check-actions-security`` action in the CI as described [here](https://dev.docs.pyansys.com/how-to/vulnerabilities.html#fixing-common-issues-detected-by-zizmor) under the paragraph "unpinned-uses": Unpinned ``uses:`` clauses in GitHub Actions represent a vulnerability as it allows workflows to pull in action code that can be changed at any time by attackers, leading to unexpected or malicious code execution.

The [pinact](https://github.com/suzuki-shunsuke/pinact) tool is used to perform this update. 
The latest release v10.1.5 of ``ansys/actions`` is used. For actions from other sources, the version is updated to the latest release available.