### PR TITLE
FIX: Update AEDT version handling and source assignment for 2026.1

### DIFF
--- a/examples/high_frequency/multiphysics/hfss_mechanical.py
+++ b/examples/high_frequency/multiphysics/hfss_mechanical.py
@@ -21,7 +21,7 @@ from ansys.aedt.core.examples.downloads import download_via_wizard
 
 # Define constants.
 
-AEDT_VERSION = "2025.2"
+AEDT_VERSION = "2026.1"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 
@@ -92,10 +92,12 @@ circuit.modeler.schematic.create_interface_port(
     location=[hfss_comp.pins[3].location[0], hfss_comp.pins[3].location[1]],
 )
 
-ports_list = ["Excitation_1", "Excitation_2"]
-source = circuit.assign_voltage_sinusoidal_excitation_to_ports(ports_list)
-source.ac_magnitude = 1
-source.phase = 0
+# Source assignment is not working in 2026R1 due to a known bug in AEDT.
+if AEDT_VERSION != "2026.1":
+    ports_list = ["Excitation_1", "Excitation_2"]
+    source = circuit.assign_voltage_sinusoidal_excitation_to_ports(ports_list)
+    source.ac_magnitude = 1
+    source.phase = 0
 # -
 
 # ## Create setup
@@ -111,7 +113,10 @@ LNA_setup.props["SweepDefinition"]["Data"] = " ".join(sweep_list)
 # correct value of losses.
 
 circuit.analyze(cores=NUM_CORES)
-circuit.push_excitations(instance="S1", setup=setup_name)
+
+# If source is not assigned to port, the push excitation fails
+if AEDT_VERSION != "2026.1":
+    circuit.push_excitations(instance="S1", setup=setup_name)
 
 # ## Start Mechanical
 #


### PR DESCRIPTION
## Description
This pull request updates the `hfss_mechanical.py` example to support AEDT version 2026.1 and adds workarounds for a known issue with source assignment in this release. The main changes ensure compatibility with the new AEDT version while preventing failures due to the bug.

**AEDT version update and compatibility workaround:**

* Updated the `AEDT_VERSION` constant from `"2025.2"` to `"2026.1"` to target the latest release, and because 2025R2 is delete on the VMs.

* Added conditional logic to skip source assignment and excitation push steps if running with AEDT version `2026.1`, due to a known bug in this version that prevents source assignment from working.

## Issue linked
No issue linked

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
