### PR TITLE
FIX: Delete deprecated arguments

### DIFF
--- a/examples/aedt_general/report/virtual_compliance.py
+++ b/examples/aedt_general/report/virtual_compliance.py
@@ -75,9 +75,11 @@ status, diff_pairs, comm_pairs = circuit.create_lna_schematic_from_snp(
     stop_frequency=70,
     auto_assign_diff_pairs=True,
     separation=".",
-    pattern=["component", "pin", "net"],
-    analyze=True,
+    pattern=["component", "pin", "net"]
 )
+circuit.design_name = "LNA"
+circuit.analyze(cores=NUM_CORES)
+
 insertion = circuit.get_all_insertion_loss_list(
     drivers=diff_pairs,
     receivers=diff_pairs,
@@ -106,16 +108,18 @@ return_comm = circuit.get_all_return_loss_list(
 # The original circuit schematic is duplicated and modified to achieve this target.
 
 result, tdr_probe_name = circuit.create_tdr_schematic_from_snp(
-    input_file=touchstone_path,
+    input_file=str(touchstone_path),
     tx_schematic_pins=["X1.A2.PCIe_Gen4_RX0_P"],
     tx_schematic_differential_pins=["X1.A3.PCIe_Gen4_RX0_N"],
     termination_pins=["U1.AP26.PCIe_Gen4_RX0_P", "U1.AN26.PCIe_Gen4_RX0_N"],
     differential=True,
     rise_time=35,
     use_convolution=True,
-    analyze=True,
     design_name="TDR",
 )
+
+circuit.design_name = "TDR"
+circuit.analyze(cores=NUM_CORES)
 
 # ## Create AMI project
 #
@@ -123,7 +127,7 @@ result, tdr_probe_name = circuit.create_tdr_schematic_from_snp(
 # eye mask violations.
 
 _, eye_curve_tx, eye_curve_rx = circuit.create_ami_schematic_from_snp(
-    input_file=touchstone_path,
+    input_file=str(touchstone_path),
     ibis_tx_file=os.path.join(project_folder, "models", "pcieg5_32gt.ibs"),
     tx_buffer_name="1p",
     rx_buffer_name="2p",
@@ -137,9 +141,11 @@ _, eye_curve_tx, eye_curve_rx = circuit.create_ami_schematic_from_snp(
     bit_pattern="random_bit_count=2.5e3 random_seed=1",
     unit_interval="31.25ps",
     use_convolution=True,
-    analyze=True,
     design_name="AMI",
 )
+
+circuit.design_name = "AMI"
+circuit.analyze(cores=NUM_CORES)
 
 circuit.save_project()
 

--- a/examples/aedt_general/report/virtual_compliance.py
+++ b/examples/aedt_general/report/virtual_compliance.py
@@ -61,7 +61,7 @@ h3d.setups[0].sweeps[0].props["EnforceCausality"] = True
 h3d.setups[0].sweeps[0].update()
 h3d.analyze(cores=NUM_CORES)
 h3d = ansys.aedt.core.Hfss3dLayout()
-touchstone_path = h3d.export_touchstone()  # Returns false.
+touchstone_path = h3d.export_touchstone()
 
 # ## Create LNA project
 #
@@ -108,7 +108,7 @@ return_comm = circuit.get_all_return_loss_list(
 # The original circuit schematic is duplicated and modified to achieve this target.
 
 result, tdr_probe_name = circuit.create_tdr_schematic_from_snp(
-    input_file=str(touchstone_path),
+    input_file=touchstone_path,
     tx_schematic_pins=["X1.A2.PCIe_Gen4_RX0_P"],
     tx_schematic_differential_pins=["X1.A3.PCIe_Gen4_RX0_N"],
     termination_pins=["U1.AP26.PCIe_Gen4_RX0_P", "U1.AN26.PCIe_Gen4_RX0_N"],
@@ -127,7 +127,7 @@ circuit.analyze(cores=NUM_CORES)
 # eye mask violations.
 
 _, eye_curve_tx, eye_curve_rx = circuit.create_ami_schematic_from_snp(
-    input_file=str(touchstone_path),
+    input_file=touchstone_path,
     ibis_tx_file=os.path.join(project_folder, "models", "pcieg5_32gt.ibs"),
     tx_buffer_name="1p",
     rx_buffer_name="2p",
@@ -161,7 +161,7 @@ circuit.save_project()
 
 template = os.path.join(download_folder, "pcie_gen5_templates", "main.json")
 
-v = VirtualCompliance(circuit.desktop_class, str(template))
+v = VirtualCompliance(circuit.desktop_class, template)
 
 # ## Customize project and design
 #

--- a/examples/aedt_general/report/virtual_compliance.py
+++ b/examples/aedt_general/report/virtual_compliance.py
@@ -107,7 +107,7 @@ return_comm = circuit.get_all_return_loss_list(
 # the TDR measurement on a differential pair.
 # The original circuit schematic is duplicated and modified to achieve this target.
 
-result, tdr_probe_name = circuit.create_tdr_schematic_from_snp(
+tdr_probe_name = circuit.create_tdr_schematic_from_snp(
     input_file=touchstone_path,
     tx_schematic_pins=["X1.A2.PCIe_Gen4_RX0_P"],
     tx_schematic_differential_pins=["X1.A3.PCIe_Gen4_RX0_N"],

--- a/examples/electrothermal/three_phase_inverter.py
+++ b/examples/electrothermal/three_phase_inverter.py
@@ -116,7 +116,7 @@ for pin in comp.pins:
         location=[pin.location[0] + ammeter_x_factor, pin.location[1] - ammeter_y_factor],
         angle=angle_ammeter,
     )
-    comp_page_port = tb.modeler.components.create_page_port(name=terminal, location=ammeter.pins[0].location, label_position=label_position, angle=angle_page_port)
+    comp_page_port = tb.modeler.schematic.create_page_port(name=terminal, location=ammeter.pins[0].location, label_position=label_position, angle=angle_page_port)
     tb.modeler.schematic.create_wire([ammeter.pins[1].location, pin.location])
 
 # ## Solve transient setup

--- a/examples/electrothermal/three_phase_inverter.py
+++ b/examples/electrothermal/three_phase_inverter.py
@@ -288,7 +288,7 @@ ipk.copy_solid_bodies_from(q3d, assignment=copy_bodies_from_q3d, include_sheets=
 ipk.modeler.change_region_padding(
     padding_data=[100, 100, 50, 50, "200mm", "200mm"], padding_type=["Percentage Offset", "Percentage Offset", "Percentage Offset", "Percentage Offset", "Absolute Offset", "Absolute Offset"]
 )
-ipk.modeler.get_objects_by_material("air")[0].model = False
+ipk.modeler.get_objects_by_material("air")[0].is_model = False
 subregion = ipk.modeler.create_subregion(padding_values=[10, 10, 10, 10, 50, 50], padding_types="Percentage Offset", assignment=["dc_terminal", "dc_terminal_1_2"], name="Subregion")
 
 # ## Assign EM losses

--- a/examples/high_frequency/antenna/large_scenarios/reflector.py
+++ b/examples/high_frequency/antenna/large_scenarios/reflector.py
@@ -90,7 +90,7 @@ target.analyze(cores=NUM_CORES)
 #
 # Plot results in AEDT.
 
-variations = target.available_variations.get_independent_nominal_values()
+variations = target.available_variations.nominal_variation(dependent_params=False)
 variations["Freq"] = ["10GHz"]
 variations["Theta"] = ["All"]
 variations["Phi"] = ["All"]

--- a/examples/high_frequency/multiphysics/hfss_mechanical.py
+++ b/examples/high_frequency/multiphysics/hfss_mechanical.py
@@ -21,7 +21,7 @@ from ansys.aedt.core.examples.downloads import download_via_wizard
 
 # Define constants.
 
-AEDT_VERSION = "2025.2"
+AEDT_VERSION = "2026.1"
 NUM_CORES = 4
 NG_MODE = False  # Open AEDT UI when it is launched.
 
@@ -92,10 +92,12 @@ circuit.modeler.schematic.create_interface_port(
     location=[hfss_comp.pins[3].location[0], hfss_comp.pins[3].location[1]],
 )
 
-ports_list = ["Excitation_1", "Excitation_2"]
-source = circuit.assign_voltage_sinusoidal_excitation_to_ports(ports_list)
-source.ac_magnitude = 1
-source.phase = 0
+# Source assignment is not working in 2026R1 due to a known bug in AEDT.
+if AEDT_VERSION != "2026.1":
+    ports_list = ["Excitation_1", "Excitation_2"]
+    source = circuit.assign_voltage_sinusoidal_excitation_to_ports(ports_list)
+    source.ac_magnitude = 1
+    source.phase = 0
 # -
 
 # ## Create setup
@@ -111,7 +113,10 @@ LNA_setup.props["SweepDefinition"]["Data"] = " ".join(sweep_list)
 # correct value of losses.
 
 circuit.analyze(cores=NUM_CORES)
-circuit.push_excitations(instance="S1", setup=setup_name)
+
+# If source is not assigned to port, the push excitation fails
+if AEDT_VERSION != "2026.1":
+    circuit.push_excitations(instance="S1", setup=setup_name)
 
 # ## Start Mechanical
 #

--- a/examples/high_frequency/multiphysics/mri.py
+++ b/examples/high_frequency/multiphysics/mri.py
@@ -319,7 +319,7 @@ mesh_box = ipk.modeler.create_box(
     origin=bound[:3],
     sizes=[bound[3] - bound[0], bound[4] - bound[1], bound[5] - bound[2]],
 )
-mesh_box.model = False
+mesh_box.is_model = False
 mesh_region = ipk.mesh.assign_mesh_region([mesh_box.name])
 mesh_region.UserSpecifiedSettings = False
 mesh_region.update()


### PR DESCRIPTION
## Description
This pull request updates several example scripts to improve clarity and correctness in how circuit analysis and modeling are performed, as well as to fix property assignments for model objects. The main changes are grouped into improvements for circuit analysis workflow and corrections to property names for model objects.

**Circuit analysis workflow improvements:**

* Refactored the workflow in `virtual_compliance.py` to explicitly set the `design_name` and call `analyze()` with the desired number of cores (`NUM_CORES`) after creating each schematic (main, TDR, and AMI), instead of relying on the `analyze` parameter in function calls. This makes the analysis steps clearer and more explicit.

**Corrections to model object property assignments:**

* Fixed property assignments from `.model = False` to `.is_model = False` for objects returned by `get_objects_by_material("air")` in `three_phase_inverter.py` and for `mesh_box` in `mri.py`, aligning with the correct attribute name.

## Issue linked
No issue linked

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
