### PR TITLE
FIX: Skip solving

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -397,7 +397,7 @@ def patch_notebook_parser_with_timer():
         _timings[docname] = elapsed
         duration_str = _format_duration(elapsed)
         # ::notice:: renders as an annotation in the GitHub Actions UI
-        print(f"::notice file={docname}.ipynb::[timing] {docname} -> {duration_str}", flush=True)
+        print(f"::notice file={docname}.ipynb::[timing] {docname}: {duration_str}", flush=True)
 
     _nbsphinx.NotebookParser.parse = _timed_parse
 
@@ -409,6 +409,8 @@ def patch_notebook_parser_with_timer():
         sorted_timings = sorted(_timings.items(), key=lambda x: x[1], reverse=True)
         total = sum(t for _, t in sorted_timings)
 
+        top10 = sorted_timings[:10]
+
         lines = [
             "## Notebook execution times",
             "",
@@ -418,10 +420,24 @@ def patch_notebook_parser_with_timer():
             "|------|----------|----------|",
         ]
         for rank, (doc, secs) in enumerate(sorted_timings, start=1):
-            slow = " :turtle: SLOW" if secs > 300 else ""
+            slow = " SLOW" if secs > 300 else ""
             lines.append(f"| {rank} | `{doc}` | **{_format_duration(secs)}**{slow} |")
         lines.append("")
         report = "\n".join(lines)
+
+        # Top-10 slowest summary printed to CI log
+        summary_lines = [
+            "",
+            "=" * 60,
+            "TOP 10 SLOWEST NOTEBOOKS",
+            "=" * 60,
+        ]
+        for rank, (doc, secs) in enumerate(top10, start=1):
+            slow = "  <-- SLOW" if secs > 300 else ""
+            summary_lines.append(f"  {rank:>2}. {_format_duration(secs):>10}  {doc}{slow}")
+        summary_lines.append("=" * 60)
+        summary_lines.append("")
+        print("\n".join(summary_lines), flush=True)
 
         summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
         if summary_path:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -462,10 +462,11 @@ def setup(app):
     # Source read hook
     app.connect("source-read", adjust_image_path)
     # Build finished hooks
-    # patch_notebook_parser_with_timer returns a build-finished hook that writes
-    # the timing summary table; the monkey-patch is applied immediately (at
-    # conf.py import time) so timings are collected during "reading sources".
-    app.connect("build-finished", patch_notebook_parser_with_timer())
+    # patch_notebook_parser_with_timer applies the monkey-patch immediately and
+    # returns a build-finished hook that writes the timing summary.  Call it once
+    # and register the returned hook to avoid duplicating the summary output.
+    timing_summary_hook = patch_notebook_parser_with_timer()
+    app.connect("build-finished", timing_summary_hook)
     app.connect("build-finished", remove_examples)
     app.connect("build-finished", remove_doctree)
     app.connect("build-finished", copy_script_examples)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -352,6 +352,84 @@ def convert_examples_into_notebooks(app):
             logger.info(f"Converted {count} python examples to scripts")
 
 
+def patch_notebook_parser_with_timer():
+    """Monkey-patch nbsphinx.NotebookParser.parse to log execution time per notebook.
+
+    Each notebook parse (which includes execution) is timed and the duration is
+    printed to stdout immediately so it is visible in the CI/CD streaming logs.
+    The format ``::notice file=<path>::`` makes the line appear as an annotation
+    in the GitHub Actions UI.
+    At the end of the build the ``build-finished`` hook writes a full Markdown
+    table to ``$GITHUB_STEP_SUMMARY`` (the GitHub Actions Job Summary page).
+    """
+    import time
+    import nbsphinx as _nbsphinx
+
+    _original_parse = _nbsphinx.NotebookParser.parse
+
+    # Shared registry: docname -> elapsed seconds
+    _timings: dict[str, float] = {}
+
+    def _timed_parse(self, inputstring, document):
+        env = document.settings.env
+        docname = env.docname
+        t0 = time.monotonic()
+        _original_parse(self, inputstring, document)
+        elapsed = time.monotonic() - t0
+        _timings[docname] = elapsed
+
+        duration_str = _format_duration(elapsed)
+        # Print immediately so the time is visible in streaming CI logs
+        # ::notice:: renders as an annotation in GitHub Actions
+        on_ci = os.environ.get("ON_CI", "")
+        prefix = f"::notice file={docname}.ipynb::" if on_ci else ""
+        print(f"{prefix}[timing] {docname} — {duration_str}", flush=True)
+
+    _nbsphinx.NotebookParser.parse = _timed_parse
+
+    def _write_timing_summary(app, exception):
+        """Write the full timing table to $GITHUB_STEP_SUMMARY."""
+        if not _timings:
+            return
+        sorted_timings = sorted(_timings.items(), key=lambda x: x[1], reverse=True)
+        total = sum(t for _, t in sorted_timings)
+
+        lines = [
+            "## Notebook execution times",
+            "",
+            f"**Total:** {_format_duration(total)} across {len(sorted_timings)} notebook(s)",
+            "",
+            "| # | Notebook | Duration |",
+            "|---|----------|----------|",
+        ]
+        for rank, (doc, secs) in enumerate(sorted_timings, start=1):
+            marker = " SLOW" if secs > 300 else ""
+            lines.append(f"| {rank} | `{doc}` | **{_format_duration(secs)}**{marker} |")
+        lines.append("")
+        report = "\n".join(lines)
+
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(report + "\n")
+            logger.info(f"[timing] Notebook timing summary written to GITHUB_STEP_SUMMARY.")
+        else:
+            logger.info(report)
+
+    return _write_timing_summary
+
+
+def _format_duration(seconds: float) -> str:
+    """Format seconds as a human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{int(minutes)}m {secs:.0f}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{int(hours)}h {int(minutes)}m {secs:.0f}s"
+
+
 def setup(app):
     """Run different hook functions during the documentation build."""
     app.add_directive("pprint", PrettyPrintDirective)
@@ -367,6 +445,9 @@ def setup(app):
     app.connect("build-finished", remove_examples)
     app.connect("build-finished", remove_doctree)
     app.connect("build-finished", copy_script_examples)
+    # Timing: patch nbsphinx parser and register the summary hook
+    write_timing_summary = patch_notebook_parser_with_timer()
+    app.connect("build-finished", write_timing_summary)
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -409,7 +409,7 @@ def patch_notebook_parser_with_timer():
         sorted_timings = sorted(_timings.items(), key=lambda x: x[1], reverse=True)
         total = sum(t for _, t in sorted_timings)
 
-        top10 = sorted_timings[:10]
+        top_n = [item for item in sorted_timings[:10] if item[1] >= 60]
 
         lines = [
             "## Notebook execution times",
@@ -425,14 +425,14 @@ def patch_notebook_parser_with_timer():
         lines.append("")
         report = "\n".join(lines)
 
-        # Top-10 slowest summary printed to CI log
+        # Top-N slowest summary printed to CI log
         summary_lines = [
             "",
             "=" * 60,
-            "TOP 10 SLOWEST NOTEBOOKS",
+            f"TOP {len(top_n)} SLOWEST NOTEBOOKS",
             "=" * 60,
         ]
-        for rank, (doc, secs) in enumerate(top10, start=1):
+        for rank, (doc, secs) in enumerate(top_n, start=1):
             slow = "  <-- SLOW" if secs > 300 else ""
             summary_lines.append(f"  {rank:>2}. {_format_duration(secs):>10}  {doc}{slow}")
         summary_lines.append("=" * 60)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -405,13 +405,18 @@ def report_notebook_execution_times(app: Sphinx, exception: None | Exception):
     kernel execution time per notebook, prints each one immediately to stdout
     (visible in streaming CI logs) and writes a Markdown summary table to
     ``$GITHUB_STEP_SUMMARY`` (the GitHub Actions Job Summary tab).
+
+    This function is a no-op when not running on CI (i.e. when the ``ON_CI``
+    environment variable is not set) to avoid verbose output during local builds.
     """
+    if not bool(os.environ.get("ON_CI", "")):
+        return
+
     auxdir = Path(app.doctreedir) / "nbsphinx"
     if not auxdir.exists():
         logger.warning("[timing] nbsphinx aux dir not found, skipping timing report.")
         return
 
-    on_ci = bool(os.environ.get("ON_CI", ""))
     timings: list[tuple[float, str]] = []  # (seconds, docname)
 
     for nb_path in sorted(auxdir.rglob("*.ipynb")):
@@ -426,12 +431,8 @@ def report_notebook_execution_times(app: Sphinx, exception: None | Exception):
 
         timings.append((secs, docname))
         duration_str = _format_duration(secs)
-        # Emit immediately so the line appears in streaming CI logs.
-        # On GitHub Actions use ::notice:: so it shows as an annotation.
-        if on_ci:
-            print(f"::notice::[timing] {docname} : {duration_str}", flush=True)
-        else:
-            print(f"[timing] {docname} : {duration_str}", flush=True)
+        # ::notice:: renders as an annotation in the GitHub Actions UI
+        print(f"::notice::[timing] {docname} -> {duration_str}", flush=True)
 
     if not timings:
         logger.warning("[timing] No executed notebooks found, nothing to report.")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -371,22 +371,15 @@ def patch_notebook_parser_with_timer():
     logs.  At the end of the build the ``build-finished`` hook writes a
     Markdown table to ``$GITHUB_STEP_SUMMARY``.
 
-    This function is a no-op when not running on CI (``ON_CI`` env var unset).
-    It returns the ``build-finished`` hook to register with Sphinx.
+    It returns the ``build-finished`` hook that writes the timing summary.
     """
-    if not bool(os.environ.get("ON_CI", "")):
-        # Not on CI — return a no-op hook so the caller can still connect it.
-        def _noop(app, exception):
-            pass
-        return _noop
-
     import time
-    import nbsphinx as _nbsphinx
+    import nbsphinx
 
     # Shared registry: docname -> elapsed seconds
     _timings: dict[str, float] = {}
 
-    _original_parse = _nbsphinx.NotebookParser.parse
+    _original_parse = nbsphinx.NotebookParser.parse
 
     def _timed_parse(self, inputstring, document):
         env = document.settings.env
@@ -395,11 +388,8 @@ def patch_notebook_parser_with_timer():
         _original_parse(self, inputstring, document)
         elapsed = time.monotonic() - t0
         _timings[docname] = elapsed
-        duration_str = _format_duration(elapsed)
-        # ::notice:: renders as an annotation in the GitHub Actions UI
-        print(f"::notice file={docname}.ipynb::[timing] {docname}: {duration_str}", flush=True)
 
-    _nbsphinx.NotebookParser.parse = _timed_parse
+    nbsphinx.NotebookParser.parse = _timed_parse
 
     def _write_timing_summary(app, exception):
         """Write the full timing table to $GITHUB_STEP_SUMMARY."""
@@ -471,11 +461,8 @@ def setup(app):
     # Source read hook
     app.connect("source-read", adjust_image_path)
     # Build finished hooks
-    # patch_notebook_parser_with_timer applies the monkey-patch immediately and
-    # returns a build-finished hook that writes the timing summary.  Call it once
-    # and register the returned hook to avoid duplicating the summary output.
-    timing_summary_hook = patch_notebook_parser_with_timer()
-    app.connect("build-finished", timing_summary_hook)
+    if bool(os.environ.get("ON_CI", "")):
+        app.connect("build-finished", patch_notebook_parser_with_timer())
     app.connect("build-finished", remove_examples)
     app.connect("build-finished", remove_doctree)
     app.connect("build-finished", copy_script_examples)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -403,6 +403,12 @@ def patch_notebook_parser_with_timer():
 
     def _write_timing_summary(app, exception):
         """Write the full timing table to $GITHUB_STEP_SUMMARY."""
+        # Guard: only run once per CI process (HTML + PDF builds share the same process).
+        if os.environ.get("_TIMING_SUMMARY_WRITTEN"):
+            logger.info("[timing] Notebook timing summary already written, skipping.")
+            return
+        os.environ["_TIMING_SUMMARY_WRITTEN"] = "1"
+
         if not _timings:
             logger.warning("[timing] No notebooks were timed.")
             return
@@ -425,29 +431,22 @@ def patch_notebook_parser_with_timer():
         lines.append("")
         report = "\n".join(lines)
 
-        # Top-N slowest summary printed to CI log (once per process)
-        if not os.environ.get("_TIMING_SUMMARY_WRITTEN"):
-            summary_lines = [
-                "",
-                "=" * 60,
-                f"TOP {len(top_n)} SLOWEST NOTEBOOKS",
-                "=" * 60,
-            ]
-            for rank, (doc, secs) in enumerate(top_n, start=1):
-                slow = " SLOW (more than 5 minutes)" if secs > 300 else ""
-                summary_lines.append(f"  {rank:>2}. {_format_duration(secs):>10}  {doc}{slow}")
-            summary_lines.append("=" * 60)
-            summary_lines.append("")
-            print("\n".join(summary_lines), flush=True)
+        # Top-N slowest summary printed to CI log
+        summary_lines = [
+            "",
+            "=" * 60,
+            f"TOP {len(top_n)} SLOWEST NOTEBOOKS",
+            "=" * 60,
+        ]
+        for rank, (doc, secs) in enumerate(top_n, start=1):
+            slow = " SLOW (more than 5 minutes)" if secs > 300 else ""
+            summary_lines.append(f"  {rank:>2}. {_format_duration(secs):>10}  {doc}{slow}")
+        summary_lines.append("=" * 60)
+        summary_lines.append("")
+        print("\n".join(summary_lines), flush=True)
 
         summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
         if summary_path:
-            # Use a sentinel env var to avoid writing the summary twice if
-            # Sphinx is invoked more than once in the same process (e.g. HTML + PDF).
-            if os.environ.get("_TIMING_SUMMARY_WRITTEN"):
-                logger.info("[timing] Notebook timing summary already written, skipping.")
-                return
-            os.environ["_TIMING_SUMMARY_WRITTEN"] = "1"
             with open(summary_path, "a", encoding="utf-8") as fh:
                 fh.write(report + "\n")
             logger.info("[timing] Notebook timing summary written to GITHUB_STEP_SUMMARY.")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -425,22 +425,29 @@ def patch_notebook_parser_with_timer():
         lines.append("")
         report = "\n".join(lines)
 
-        # Top-N slowest summary printed to CI log
-        summary_lines = [
-            "",
-            "=" * 60,
-            f"TOP {len(top_n)} SLOWEST NOTEBOOKS",
-            "=" * 60,
-        ]
-        for rank, (doc, secs) in enumerate(top_n, start=1):
-            slow = "  <-- SLOW" if secs > 300 else ""
-            summary_lines.append(f"  {rank:>2}. {_format_duration(secs):>10}  {doc}{slow}")
-        summary_lines.append("=" * 60)
-        summary_lines.append("")
-        print("\n".join(summary_lines), flush=True)
+        # Top-N slowest summary printed to CI log (once per process)
+        if not os.environ.get("_TIMING_SUMMARY_WRITTEN"):
+            summary_lines = [
+                "",
+                "=" * 60,
+                f"TOP {len(top_n)} SLOWEST NOTEBOOKS",
+                "=" * 60,
+            ]
+            for rank, (doc, secs) in enumerate(top_n, start=1):
+                slow = " SLOW (more than 5 minutes)" if secs > 300 else ""
+                summary_lines.append(f"  {rank:>2}. {_format_duration(secs):>10}  {doc}{slow}")
+            summary_lines.append("=" * 60)
+            summary_lines.append("")
+            print("\n".join(summary_lines), flush=True)
 
         summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
         if summary_path:
+            # Use a sentinel env var to avoid writing the summary twice if
+            # Sphinx is invoked more than once in the same process (e.g. HTML + PDF).
+            if os.environ.get("_TIMING_SUMMARY_WRITTEN"):
+                logger.info("[timing] Notebook timing summary already written, skipping.")
+                return
+            os.environ["_TIMING_SUMMARY_WRITTEN"] = "1"
             with open(summary_path, "a", encoding="utf-8") as fh:
                 fh.write(report + "\n")
             logger.info("[timing] Notebook timing summary written to GITHUB_STEP_SUMMARY.")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -409,17 +409,17 @@ def patch_notebook_parser_with_timer():
         sorted_timings = sorted(_timings.items(), key=lambda x: x[1], reverse=True)
         total = sum(t for _, t in sorted_timings)
 
-        top_n = [item for item in sorted_timings[:10] if item[1] >= 60]
+        top_n = [item for item in sorted_timings if item[1] >= 60][:10]
 
         lines = [
-            "## Notebook execution times",
+            "## Top 10 slowest notebooks (>= 1 min)",
             "",
             f"**Total:** {_format_duration(total)} across {len(sorted_timings)} notebook(s)",
             "",
             "| Rank | Notebook | Duration |",
             "|------|----------|----------|",
         ]
-        for rank, (doc, secs) in enumerate(sorted_timings, start=1):
+        for rank, (doc, secs) in enumerate(top_n, start=1):
             slow = " SLOW" if secs > 300 else ""
             lines.append(f"| {rank} | `{doc}` | **{_format_duration(secs)}**{slow} |")
         lines.append("")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -403,11 +403,14 @@ def patch_notebook_parser_with_timer():
 
     def _write_timing_summary(app, exception):
         """Write the full timing table to $GITHUB_STEP_SUMMARY."""
-        # Guard: only run once per CI process (HTML + PDF builds share the same process).
-        if os.environ.get("_TIMING_SUMMARY_WRITTEN"):
-            logger.info("[timing] Notebook timing summary already written, skipping.")
+        # In the HTML+PDF workflow on CI, skip the summary for the PDF (latex) build
+        # to avoid printing the Top 10 table twice (once per sphinx-build invocation).
+        if (
+            bool(int(os.getenv("SPHINXBUILD_HTML_AND_PDF_WORKFLOW", "0")))
+            and app.builder.name == "latex"
+        ):
+            logger.info("[timing] Skipping timing summary for PDF build in HTML+PDF workflow.")
             return
-        os.environ["_TIMING_SUMMARY_WRITTEN"] = "1"
 
         if not _timings:
             logger.warning("[timing] No notebooks were timed.")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -363,107 +363,75 @@ def _format_duration(seconds: float) -> str:
     return f"{int(hours)}h {int(minutes)}m {secs:.0f}s"
 
 
-def _notebook_execution_seconds(nb_path: Path) -> float | None:
-    """Return the total kernel execution time (seconds) for an executed notebook.
+def patch_notebook_parser_with_timer():
+    """Monkey-patch nbsphinx.NotebookParser.parse to log wall-clock time per notebook.
 
-    Reads the ``metadata.execution`` timestamps that nbconvert's
-    ExecutePreprocessor writes into every code cell after running it.
-    Returns ``None`` if no timing information is found (e.g. the notebook
-    was not executed).
-    """
-    import json
-    try:
-        with open(nb_path, encoding="utf-8") as fh:
-            nb = json.load(fh)
-    except Exception:
-        return None
+    Each notebook parse (which includes kernel execution) is timed and the
+    duration is printed immediately to stdout so it is visible in CI streaming
+    logs.  At the end of the build the ``build-finished`` hook writes a
+    Markdown table to ``$GITHUB_STEP_SUMMARY``.
 
-    total = 0.0
-    found = False
-    for cell in nb.get("cells", []):
-        exec_meta = cell.get("metadata", {}).get("execution", {})
-        start = exec_meta.get("iopub.execute_input")
-        end = exec_meta.get("iopub.status.idle")
-        if start and end:
-            from datetime import datetime
-            try:
-                t_start = datetime.fromisoformat(start)
-                t_end = datetime.fromisoformat(end)
-                total += (t_end - t_start).total_seconds()
-                found = True
-            except ValueError:
-                pass
-    return total if found else None
-
-
-def report_notebook_execution_times(app: Sphinx, exception: None | Exception):
-    """Read executed notebooks from the nbsphinx aux dir and report timings.
-
-    nbsphinx saves the executed notebook (with cell timing metadata written by
-    nbconvert's ExecutePreprocessor) to ``doctreedir/nbsphinx/<docname>.ipynb``
-    right after execution.  This hook reads those files, extracts the real
-    kernel execution time per notebook, prints each one immediately to stdout
-    (visible in streaming CI logs) and writes a Markdown summary table to
-    ``$GITHUB_STEP_SUMMARY`` (the GitHub Actions Job Summary tab).
-
-    This function is a no-op when not running on CI (i.e. when the ``ON_CI``
-    environment variable is not set) to avoid verbose output during local builds.
+    This function is a no-op when not running on CI (``ON_CI`` env var unset).
+    It returns the ``build-finished`` hook to register with Sphinx.
     """
     if not bool(os.environ.get("ON_CI", "")):
-        return
+        # Not on CI — return a no-op hook so the caller can still connect it.
+        def _noop(app, exception):
+            pass
+        return _noop
 
-    auxdir = Path(app.doctreedir) / "nbsphinx"
-    if not auxdir.exists():
-        logger.warning("[timing] nbsphinx aux dir not found, skipping timing report.")
-        return
+    import time
+    import nbsphinx as _nbsphinx
 
-    timings: list[tuple[float, str]] = []  # (seconds, docname)
+    # Shared registry: docname -> elapsed seconds
+    _timings: dict[str, float] = {}
 
-    for nb_path in sorted(auxdir.rglob("*.ipynb")):
-        secs = _notebook_execution_seconds(nb_path)
-        if secs is None:
-            continue
-        # Derive a clean docname relative to the auxdir
-        try:
-            docname = nb_path.relative_to(auxdir).with_suffix("").as_posix()
-        except ValueError:
-            docname = nb_path.stem
+    _original_parse = _nbsphinx.NotebookParser.parse
 
-        timings.append((secs, docname))
-        duration_str = _format_duration(secs)
+    def _timed_parse(self, inputstring, document):
+        env = document.settings.env
+        docname = env.docname
+        t0 = time.monotonic()
+        _original_parse(self, inputstring, document)
+        elapsed = time.monotonic() - t0
+        _timings[docname] = elapsed
+        duration_str = _format_duration(elapsed)
         # ::notice:: renders as an annotation in the GitHub Actions UI
-        print(f"::notice::[timing] {docname} -> {duration_str}", flush=True)
+        print(f"::notice file={docname}.ipynb::[timing] {docname} -> {duration_str}", flush=True)
 
-    if not timings:
-        logger.warning("[timing] No executed notebooks found, nothing to report.")
-        return
+    _nbsphinx.NotebookParser.parse = _timed_parse
 
-    # Sort slowest first
-    timings.sort(key=lambda x: x[0], reverse=True)
-    total = sum(s for s, _ in timings)
+    def _write_timing_summary(app, exception):
+        """Write the full timing table to $GITHUB_STEP_SUMMARY."""
+        if not _timings:
+            logger.warning("[timing] No notebooks were timed.")
+            return
+        sorted_timings = sorted(_timings.items(), key=lambda x: x[1], reverse=True)
+        total = sum(t for _, t in sorted_timings)
 
-    lines = [
-        "## Notebook execution times",
-        "",
-        f"**Total execution time:** {_format_duration(total)} across {len(timings)} notebook(s)",
-        "",
-        "| Rank | Notebook | Duration |",
-        "|------|----------|----------|",
-    ]
-    for rank, (secs, doc) in enumerate(timings, start=1):
-        slow = " (SLOW)" if secs > 300 else ""
-        lines.append(f"| {rank} | `{doc}` | **{_format_duration(secs)}**{slow} |")
-    lines.append("")
-    report = "\n".join(lines)
+        lines = [
+            "## Notebook execution times",
+            "",
+            f"**Total:** {_format_duration(total)} across {len(sorted_timings)} notebook(s)",
+            "",
+            "| Rank | Notebook | Duration |",
+            "|------|----------|----------|",
+        ]
+        for rank, (doc, secs) in enumerate(sorted_timings, start=1):
+            slow = " :turtle: SLOW" if secs > 300 else ""
+            lines.append(f"| {rank} | `{doc}` | **{_format_duration(secs)}**{slow} |")
+        lines.append("")
+        report = "\n".join(lines)
 
-    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if summary_path:
-        with open(summary_path, "a", encoding="utf-8") as fh:
-            fh.write(report + "\n")
-        logger.info("[timing] Notebook timing summary written to GITHUB_STEP_SUMMARY.")
-    else:
-        logger.info(report)
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(report + "\n")
+            logger.info("[timing] Notebook timing summary written to GITHUB_STEP_SUMMARY.")
+        else:
+            logger.info(report)
 
+    return _write_timing_summary
 
 
 def setup(app):
@@ -478,9 +446,10 @@ def setup(app):
     # Source read hook
     app.connect("source-read", adjust_image_path)
     # Build finished hooks
-    # NOTE: report_notebook_execution_times must run BEFORE remove_doctree
-    # because the executed notebooks are stored inside doctreedir/nbsphinx/
-    app.connect("build-finished", report_notebook_execution_times)
+    # patch_notebook_parser_with_timer returns a build-finished hook that writes
+    # the timing summary table; the monkey-patch is applied immediately (at
+    # conf.py import time) so timings are collected during "reading sources".
+    app.connect("build-finished", patch_notebook_parser_with_timer())
     app.connect("build-finished", remove_examples)
     app.connect("build-finished", remove_doctree)
     app.connect("build-finished", copy_script_examples)
@@ -628,66 +597,3 @@ pyvista.FIGURE_PATH = os.path.join(os.path.abspath("./images/"), "auto-generated
 if not os.path.exists(pyvista.FIGURE_PATH):
     os.makedirs(pyvista.FIGURE_PATH)
 
-# -- Options for HTML output -------------------------------------------------
-html_short_title = html_title = "PyAEDT Examples"
-html_theme = "ansys_sphinx_theme"
-html_favicon = ansys_favicon
-
-html_context = {
-    "display_github": True,  # Integrate GitHub
-    "github_user": USERNAME,
-    "github_repo": REPOSITORY_NAME,
-    "github_version": BRANCH,
-    "doc_path": DOC_PATH,
-}
-
-# specify the location of your github repo
-html_theme_options = {
-    "logo": "ansys",
-    "github_url": f"https://github.com/{USERNAME}/{REPOSITORY_NAME}",
-    "show_prev_next": False,
-    "collapse_navigation": True,
-    "use_edit_page_button": True,
-    "show_breadcrumbs": True,
-    "additional_breadcrumbs": [
-        ("PyAnsys", "https://docs.pyansys.com/"),
-        ("PyAEDT", "https://aedt.docs.pyansys.com/"),
-    ],
-    "icon_links": [
-        {
-            "name": "Support",
-            "url": f"https://github.com/{USERNAME}/{REPOSITORY_NAME}/discussions",
-            "icon": "fa fa-comment fa-fw",
-        },
-    ],
-}
-
-html_static_path = ["_static"]
-
-# These paths are either relative to html_static_path
-# or fully qualified paths (eg. https://...)
-html_css_files = [
-    "css/custom.css",
-    "css/highlight.css",
-]
-
-# -- Options for LaTeX output ------------------------------------------------
-# additional logos for the latex coverpage
-latex_additional_files = [watermark, ansys_logo_white, ansys_logo_white_cropped]
-
-# change the preamble of latex with customized title page
-# variables are the title of pdf, watermark
-latex_elements = {"preamble": latex.generate_preamble(html_title)}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (
-        master_doc,
-        f"{project}.tex",
-        f"{project} documentation",
-        author,
-        "manual",
-    ),
-]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -613,3 +613,66 @@ pyvista.FIGURE_PATH = os.path.join(os.path.abspath("./images/"), "auto-generated
 if not os.path.exists(pyvista.FIGURE_PATH):
     os.makedirs(pyvista.FIGURE_PATH)
 
+# -- Options for HTML output -------------------------------------------------
+html_short_title = html_title = "PyAEDT Examples"
+html_theme = "ansys_sphinx_theme"
+html_favicon = ansys_favicon
+
+html_context = {
+    "display_github": True,  # Integrate GitHub
+    "github_user": USERNAME,
+    "github_repo": REPOSITORY_NAME,
+    "github_version": BRANCH,
+    "doc_path": DOC_PATH,
+}
+
+# specify the location of your github repo
+html_theme_options = {
+    "logo": "ansys",
+    "github_url": f"https://github.com/{USERNAME}/{REPOSITORY_NAME}",
+    "show_prev_next": False,
+    "collapse_navigation": True,
+    "use_edit_page_button": True,
+    "show_breadcrumbs": True,
+    "additional_breadcrumbs": [
+        ("PyAnsys", "https://docs.pyansys.com/"),
+        ("PyAEDT", "https://aedt.docs.pyansys.com/"),
+    ],
+    "icon_links": [
+        {
+            "name": "Support",
+            "url": f"https://github.com/{USERNAME}/{REPOSITORY_NAME}/discussions",
+            "icon": "fa fa-comment fa-fw",
+        },
+    ],
+}
+
+html_static_path = ["_static"]
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    "css/custom.css",
+    "css/highlight.css",
+]
+
+# -- Options for LaTeX output ------------------------------------------------
+# additional logos for the latex coverpage
+latex_additional_files = [watermark, ansys_logo_white, ansys_logo_white_cropped]
+
+# change the preamble of latex with customized title page
+# variables are the title of pdf, watermark
+latex_elements = {"preamble": latex.generate_preamble(html_title)}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title,
+#  author, documentclass [howto, manual, or own class]).
+latex_documents = [
+    (
+        master_doc,
+        f"{project}.tex",
+        f"{project} documentation",
+        author,
+        "manual",
+    ),
+]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -352,73 +352,6 @@ def convert_examples_into_notebooks(app):
             logger.info(f"Converted {count} python examples to scripts")
 
 
-def patch_notebook_parser_with_timer():
-    """Monkey-patch nbsphinx.NotebookParser.parse to log execution time per notebook.
-
-    Each notebook parse (which includes execution) is timed and the duration is
-    printed to stdout immediately so it is visible in the CI/CD streaming logs.
-    The format ``::notice file=<path>::`` makes the line appear as an annotation
-    in the GitHub Actions UI.
-    At the end of the build the ``build-finished`` hook writes a full Markdown
-    table to ``$GITHUB_STEP_SUMMARY`` (the GitHub Actions Job Summary page).
-    """
-    import time
-    import nbsphinx as _nbsphinx
-
-    _original_parse = _nbsphinx.NotebookParser.parse
-
-    # Shared registry: docname -> elapsed seconds
-    _timings: dict[str, float] = {}
-
-    def _timed_parse(self, inputstring, document):
-        env = document.settings.env
-        docname = env.docname
-        t0 = time.monotonic()
-        _original_parse(self, inputstring, document)
-        elapsed = time.monotonic() - t0
-        _timings[docname] = elapsed
-
-        duration_str = _format_duration(elapsed)
-        # Print immediately so the time is visible in streaming CI logs
-        # ::notice:: renders as an annotation in GitHub Actions
-        on_ci = os.environ.get("ON_CI", "")
-        prefix = f"::notice file={docname}.ipynb::" if on_ci else ""
-        print(f"{prefix}[timing] {docname} — {duration_str}", flush=True)
-
-    _nbsphinx.NotebookParser.parse = _timed_parse
-
-    def _write_timing_summary(app, exception):
-        """Write the full timing table to $GITHUB_STEP_SUMMARY."""
-        if not _timings:
-            return
-        sorted_timings = sorted(_timings.items(), key=lambda x: x[1], reverse=True)
-        total = sum(t for _, t in sorted_timings)
-
-        lines = [
-            "## Notebook execution times",
-            "",
-            f"**Total:** {_format_duration(total)} across {len(sorted_timings)} notebook(s)",
-            "",
-            "| # | Notebook | Duration |",
-            "|---|----------|----------|",
-        ]
-        for rank, (doc, secs) in enumerate(sorted_timings, start=1):
-            marker = " SLOW" if secs > 300 else ""
-            lines.append(f"| {rank} | `{doc}` | **{_format_duration(secs)}**{marker} |")
-        lines.append("")
-        report = "\n".join(lines)
-
-        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-        if summary_path:
-            with open(summary_path, "a", encoding="utf-8") as fh:
-                fh.write(report + "\n")
-            logger.info(f"[timing] Notebook timing summary written to GITHUB_STEP_SUMMARY.")
-        else:
-            logger.info(report)
-
-    return _write_timing_summary
-
-
 def _format_duration(seconds: float) -> str:
     """Format seconds as a human-readable string."""
     if seconds < 60:
@@ -428,6 +361,108 @@ def _format_duration(seconds: float) -> str:
         return f"{int(minutes)}m {secs:.0f}s"
     hours, minutes = divmod(minutes, 60)
     return f"{int(hours)}h {int(minutes)}m {secs:.0f}s"
+
+
+def _notebook_execution_seconds(nb_path: Path) -> float | None:
+    """Return the total kernel execution time (seconds) for an executed notebook.
+
+    Reads the ``metadata.execution`` timestamps that nbconvert's
+    ExecutePreprocessor writes into every code cell after running it.
+    Returns ``None`` if no timing information is found (e.g. the notebook
+    was not executed).
+    """
+    import json
+    try:
+        with open(nb_path, encoding="utf-8") as fh:
+            nb = json.load(fh)
+    except Exception:
+        return None
+
+    total = 0.0
+    found = False
+    for cell in nb.get("cells", []):
+        exec_meta = cell.get("metadata", {}).get("execution", {})
+        start = exec_meta.get("iopub.execute_input")
+        end = exec_meta.get("iopub.status.idle")
+        if start and end:
+            from datetime import datetime
+            try:
+                t_start = datetime.fromisoformat(start)
+                t_end = datetime.fromisoformat(end)
+                total += (t_end - t_start).total_seconds()
+                found = True
+            except ValueError:
+                pass
+    return total if found else None
+
+
+def report_notebook_execution_times(app: Sphinx, exception: None | Exception):
+    """Read executed notebooks from the nbsphinx aux dir and report timings.
+
+    nbsphinx saves the executed notebook (with cell timing metadata written by
+    nbconvert's ExecutePreprocessor) to ``doctreedir/nbsphinx/<docname>.ipynb``
+    right after execution.  This hook reads those files, extracts the real
+    kernel execution time per notebook, prints each one immediately to stdout
+    (visible in streaming CI logs) and writes a Markdown summary table to
+    ``$GITHUB_STEP_SUMMARY`` (the GitHub Actions Job Summary tab).
+    """
+    auxdir = Path(app.doctreedir) / "nbsphinx"
+    if not auxdir.exists():
+        logger.warning("[timing] nbsphinx aux dir not found, skipping timing report.")
+        return
+
+    on_ci = bool(os.environ.get("ON_CI", ""))
+    timings: list[tuple[float, str]] = []  # (seconds, docname)
+
+    for nb_path in sorted(auxdir.rglob("*.ipynb")):
+        secs = _notebook_execution_seconds(nb_path)
+        if secs is None:
+            continue
+        # Derive a clean docname relative to the auxdir
+        try:
+            docname = nb_path.relative_to(auxdir).with_suffix("").as_posix()
+        except ValueError:
+            docname = nb_path.stem
+
+        timings.append((secs, docname))
+        duration_str = _format_duration(secs)
+        # Emit immediately so the line appears in streaming CI logs.
+        # On GitHub Actions use ::notice:: so it shows as an annotation.
+        if on_ci:
+            print(f"::notice::[timing] {docname} : {duration_str}", flush=True)
+        else:
+            print(f"[timing] {docname} : {duration_str}", flush=True)
+
+    if not timings:
+        logger.warning("[timing] No executed notebooks found, nothing to report.")
+        return
+
+    # Sort slowest first
+    timings.sort(key=lambda x: x[0], reverse=True)
+    total = sum(s for s, _ in timings)
+
+    lines = [
+        "## Notebook execution times",
+        "",
+        f"**Total execution time:** {_format_duration(total)} across {len(timings)} notebook(s)",
+        "",
+        "| Rank | Notebook | Duration |",
+        "|------|----------|----------|",
+    ]
+    for rank, (secs, doc) in enumerate(timings, start=1):
+        slow = " (SLOW)" if secs > 300 else ""
+        lines.append(f"| {rank} | `{doc}` | **{_format_duration(secs)}**{slow} |")
+    lines.append("")
+    report = "\n".join(lines)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(report + "\n")
+        logger.info("[timing] Notebook timing summary written to GITHUB_STEP_SUMMARY.")
+    else:
+        logger.info(report)
+
 
 
 def setup(app):
@@ -442,12 +477,12 @@ def setup(app):
     # Source read hook
     app.connect("source-read", adjust_image_path)
     # Build finished hooks
+    # NOTE: report_notebook_execution_times must run BEFORE remove_doctree
+    # because the executed notebooks are stored inside doctreedir/nbsphinx/
+    app.connect("build-finished", report_notebook_execution_times)
     app.connect("build-finished", remove_examples)
     app.connect("build-finished", remove_doctree)
     app.connect("build-finished", copy_script_examples)
-    # Timing: patch nbsphinx parser and register the summary hook
-    write_timing_summary = patch_notebook_parser_with_timer()
-    app.connect("build-finished", write_timing_summary)
 
 
 # -- General configuration ---------------------------------------------------

--- a/examples/electrothermal/three_phase_inverter.py
+++ b/examples/electrothermal/three_phase_inverter.py
@@ -52,7 +52,7 @@ project_path = download_file(
     local_path=temp_folder.name,
 )
 
-# ## Launch Maxwell AEDT
+# ## Launch Twinbuilder AEDT
 #
 # Create an instance of the ``Twinbuilder`` class.
 # The Ansys Electronics Desktop will be launched with the active Twinbuilder design.

--- a/examples/electrothermal/three_phase_inverter.py
+++ b/examples/electrothermal/three_phase_inverter.py
@@ -28,6 +28,7 @@ NG_MODE = False  # Open AEDT UI when it is launched.
 TB_DESIGN_NAME = "3ph_circuit"
 Q3D_DESIGN_NAME = "q3d_3ph"
 ICEPAK_DESIGN_NAME = "Icepak_1"
+SOLVE_ICEPAK = False
 
 # ## Create temporary directory
 #
@@ -70,7 +71,12 @@ tb = ansys.aedt.core.TwinBuilder(
 # The component uses RLGC model extracted from the Q3D design to create a frequency sweep.
 
 comp = tb.add_q3d_dynamic_component(
-    source_project=tb.project_name, source_design_name=Q3D_DESIGN_NAME, setup="Setup1", sweep="Sweep1", coupling_matrix_name="Original", state_space_dynamic_link_type="RLGC"
+    source_project=tb.project_name,
+    source_design_name=Q3D_DESIGN_NAME,
+    setup="Setup1",
+    sweep="Sweep1",
+    coupling_matrix_name="Original",
+    state_space_dynamic_link_type="RLGC"
 )
 
 tb.set_active_design(TB_DESIGN_NAME)
@@ -116,7 +122,10 @@ for pin in comp.pins:
         location=[pin.location[0] + ammeter_x_factor, pin.location[1] - ammeter_y_factor],
         angle=angle_ammeter,
     )
-    comp_page_port = tb.modeler.schematic.create_page_port(name=terminal, location=ammeter.pins[0].location, label_position=label_position, angle=angle_page_port)
+    comp_page_port = tb.modeler.schematic.create_page_port(name=terminal,
+                                                           location=ammeter.pins[0].location,
+                                                           label_position=label_position,
+                                                           angle=angle_page_port)
     tb.modeler.schematic.create_wire([ammeter.pins[1].location, pin.location])
 
 # ## Solve transient setup
@@ -257,7 +266,9 @@ q3d.edit_sources(harmonic_loss=harmonic_loss)
 #
 # Plot the harmonic loss density on the surface of the objects
 
-plot = q3d.post.create_fieldplot_surface(["dc_terminal", "dc_terminal_1_2"], "Harmonic_Loss_Density", intrinsics={"Freq": "0.5GHz", "Phase": "0deg"})
+plot = q3d.post.create_fieldplot_surface(["dc_terminal", "dc_terminal_1_2"],
+                                         "Harmonic_Loss_Density",
+                                         intrinsics={"Freq": "0.5GHz", "Phase": "0deg"})
 q3d.save_project()
 
 fs = plot.folder_settings
@@ -285,11 +296,17 @@ ipk.copy_solid_bodies_from(q3d, assignment=copy_bodies_from_q3d, include_sheets=
 #
 # Change region padding and create subregion to enclose the objects imported from Q3D
 
+padding = ["Percentage Offset", "Percentage Offset", "Percentage Offset", "Percentage Offset",
+           "Absolute Offset", "Absolute Offset"]
 ipk.modeler.change_region_padding(
-    padding_data=[100, 100, 50, 50, "200mm", "200mm"], padding_type=["Percentage Offset", "Percentage Offset", "Percentage Offset", "Percentage Offset", "Absolute Offset", "Absolute Offset"]
+    padding_data=[100, 100, 50, 50, "200mm", "200mm"],
+    padding_type=padding
 )
 ipk.modeler.get_objects_by_material("air")[0].is_model = False
-subregion = ipk.modeler.create_subregion(padding_values=[10, 10, 10, 10, 50, 50], padding_types="Percentage Offset", assignment=["dc_terminal", "dc_terminal_1_2"], name="Subregion")
+subregion = ipk.modeler.create_subregion(padding_values=[10, 10, 10, 10, 50, 50],
+                                         padding_types="Percentage Offset",
+                                         assignment=["dc_terminal", "dc_terminal_1_2"],
+                                         name="Subregion")
 
 # ## Assign EM losses
 #
@@ -342,25 +359,27 @@ ipk.assign_stationary_wall_with_temperature(
 
 setup = ipk.create_setup()
 setup.props["Include Flow"] = False
-ipk.analyze_setup(ipk.setups[0].name)
 
 # ## Analysis
 #
 # Analyze the Icepak design
 
-ipk.analyze_setup(ipk.setups[0].name)
+if SOLVE_ICEPAK:
+    ipk.analyze_setup(ipk.setups[0].name, cores=None)
 
 # ## Icepak Post-processing
 #
 # Post-processing: plot temperature distribution and volumetric heat loss on the surface of the objects
 
-temp = ipk.post.create_fieldplot_surface(assignment=["dc_terminal", "dc_terminal_1_2"], quantity="Temperature", plot_name="Temperature")
-vol_heat_loss = ipk.post.create_fieldplot_volume(assignment=["dc_terminal", "dc_terminal_1_2"], quantity="VolumeHeatLoss", plot_name="VolumeHeatLoss")
+if SOLVE_ICEPAK:
+    temp = ipk.post.create_fieldplot_surface(assignment=["dc_terminal", "dc_terminal_1_2"], quantity="Temperature", plot_name="Temperature")
+    vol_heat_loss = ipk.post.create_fieldplot_volume(assignment=["dc_terminal", "dc_terminal_1_2"], quantity="VolumeHeatLoss", plot_name="VolumeHeatLoss")
 
 # ## Release AEDT
 
-tb.save_project()
-tb.release_desktop()
+ipk.save_project()
+ipk.release_desktop()
+
 # Wait 3 seconds to allow AEDT to shut down before cleaning the temporary directory.
 time.sleep(3)
 

--- a/examples/electrothermal/three_phase_inverter.py
+++ b/examples/electrothermal/three_phase_inverter.py
@@ -28,6 +28,8 @@ NG_MODE = False  # Open AEDT UI when it is launched.
 TB_DESIGN_NAME = "3ph_circuit"
 Q3D_DESIGN_NAME = "q3d_3ph"
 ICEPAK_DESIGN_NAME = "Icepak_1"
+# Set to True to run Icepak solve and post-processing.
+# If left as False, analyze_setup() and post-processing calls are skipped.
 SOLVE_ICEPAK = False
 
 # ## Create temporary directory

--- a/examples/high_frequency/antenna/interferences/antenna.py
+++ b/examples/high_frequency/antenna/interferences/antenna.py
@@ -92,8 +92,8 @@ if AEDT_VERSION > "2023.1":
 # Evaluate the worst-case EMI between the GPS receiver and Bluetooth radio.
 
 if AEDT_VERSION > "2023.1":
-    rx_bands = rev.get_band_names(radio_name=rad2.name, tx_rx_mode=TxRxMode.RX)
-    tx_bands = rev.get_band_names(radio_name=rad3.name, tx_rx_mode=TxRxMode.TX)
+    rx_bands = rev.get_band_names(radio_node=rad2, tx_rx_mode=TxRxMode.RX)
+    tx_bands = rev.get_band_names(radio_node=rad3, tx_rx_mode=TxRxMode.TX)
     domain = aedtapp.results.interaction_domain()
     domain.set_receiver(rad2.name, rx_bands[0], -1)
     domain.set_interferer(rad3.name, tx_bands[0])

--- a/examples/high_frequency/antenna/interferences/hfss_emit.py
+++ b/examples/high_frequency/antenna/interferences/hfss_emit.py
@@ -112,8 +112,8 @@ if AEDT_VERSION > "2023.1":
 # Evaluate the worst-case EMI between the two Bluetooth radios.
 
 if AEDT_VERSION > "2023.1":
-    rx_bands = rev.get_band_names(radio_name=rad1.name, tx_rx_mode=TxRxMode.RX)
-    tx_bands = rev.get_band_names(radio_name=rad2.name, tx_rx_mode=TxRxMode.TX)
+    rx_bands = rev.get_band_names(radio_node=rad1, tx_rx_mode=TxRxMode.RX)
+    tx_bands = rev.get_band_names(radio_node=rad2, tx_rx_mode=TxRxMode.TX)
     domain = aedtapp.results.interaction_domain()
     domain.set_receiver(rad1.name, rx_bands[0], -1)
     domain.set_interferer(rad2.name, tx_bands[0])


### PR DESCRIPTION
## Description
This pull request introduces a new feature to time and report notebook execution durations during documentation builds, along with several minor code improvements and formatting changes in example scripts. The most significant update is the addition of a timing mechanism for `nbsphinx` notebook parsing, which logs per-notebook execution times and generates a summary for CI visibility. Other changes include code formatting for readability, a bugfix in example scripts, and a new flag to control Icepak analysis.

**Notebook timing and reporting:**

* Added `patch_notebook_parser_with_timer` in `doc/source/conf.py` to monkey-patch `nbsphinx.NotebookParser.parse`, logging execution time for each notebook during the build, printing results in CI logs, and writing a Markdown summary to `$GITHUB_STEP_SUMMARY` for GitHub Actions. Also updated `setup` to register this timing hook.

**Bugfixes and API updates:**

* Updated `examples/high_frequency/antenna/interferences/antenna.py` and `hfss_emit.py` to use the correct argument name (`radio_node` instead of `radio_name`) in calls to `get_band_names`, ensuring compatibility with newer AEDT versions.

**Example script improvements:**

* Added `SOLVE_ICEPAK` flag to `examples/electrothermal/three_phase_inverter.py` to control whether Icepak analysis is executed, and updated logic to respect this flag.
* Reformatted long function calls and argument lists for better readability in `three_phase_inverter.py`.

These changes improve CI/CD feedback, code clarity, and maintain compatibility with evolving APIs.

## Issue linked
None

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
