### PR TITLE
FIX: PyVista issues

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -231,6 +231,9 @@ def skip_gif_examples_to_build_pdf(app: Sphinx):
             [
                 r".*resistance\.py",
                 r".*time_domain\.py",
+                r".*transient_winding\.py",
+                r".*coaxial_hfss_icepak\.py",
+                r".*mri\.py",
             ]
         )
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -229,9 +229,8 @@ def skip_gif_examples_to_build_pdf(app: Sphinx):
         logger.info("Examples with animations are skipped when building with latex.")
         app.config.exclude_patterns.extend(
             [
-                r".*Maxwell2D_Transient\.py",
-                r".*Maxwell2D_DCConduction\.py",
-                r".*Hfss_Icepak_Coupling\.py",
+                r".*resistance\.py",
+                r".*time_domain\.py",
             ]
         )
 

--- a/examples/electrothermal/coaxial_hfss_icepak.py
+++ b/examples/electrothermal/coaxial_hfss_icepak.py
@@ -358,7 +358,7 @@ trace_names = hfss.get_traces_for_plot(category="S")
 context = ["Domain:=", "Sweep"]
 families = ["Freq:=", ["All"]]
 my_data = hfss.post.get_solution_data(expressions=trace_names)
-my_data.plot(
+_ = my_data.plot(
     trace_names,
     formula="db20",
     x_label="Frequency (Ghz)",

--- a/examples/electrothermal/coaxial_hfss_icepak.py
+++ b/examples/electrothermal/coaxial_hfss_icepak.py
@@ -10,9 +10,13 @@
 # Perform required imports.
 
 # +
+import base64
 import os
 import tempfile
 import time
+
+from IPython.display import HTML, display
+from IPython.utils import io as ipio
 
 import ansys.aedt.core
 from ansys.aedt.core.generic.constants import Gravity, Plane, SolutionsIcepak
@@ -305,28 +309,33 @@ start = time.time()
 cutlist = ["Global:XY"]
 phase_values = [str(i * 5) + "deg" for i in range(18)]
 
-animated = hfss.post.plot_animated_field(
-    quantity="Mag_E",
-    assignment=cutlist,
-    plot_type="CutPlane",
-    setup=hfss.nominal_adaptive,
-    intrinsics=intrinsic,
-    export_path=temp_folder.name,
-    variation_variable="Phase",
-    variations=phase_values,
-    show=False,
-    export_gif=False,
-    log_scale=True,
-)
-animated.gif_file = os.path.join(temp_folder.name, "animate.gif")
+gif_file = os.path.join(temp_folder.name, "animate.gif")
 
-# Set off_screen to False to visualize the animation.
-# animated.off_screen = False
-
-animated.animate()
+with ipio.capture_output():
+    animated = hfss.post.plot_animated_field(
+        quantity="Mag_E",
+        assignment=cutlist,
+        plot_type="CutPlane",
+        setup=hfss.nominal_adaptive,
+        intrinsics=intrinsic,
+        export_path=temp_folder.name,
+        variation_variable="Phase",
+        variations=phase_values,
+        show=False,
+        export_gif=False,
+        log_scale=True,
+    )
+    animated.is_notebook = False
+    animated.off_screen = True
+    animated.gif_file = gif_file
+    animated.animate(show=False)
 
 end_time = time.time() - start
 print("Total Time", end_time)
+
+with open(gif_file, "rb") as f:
+    gif_b64 = base64.b64encode(f.read()).decode()
+display(HTML(f'<img src="data:image/gif;base64,{gif_b64}" width="600"/>'))
 # -
 
 # ## Postprocess

--- a/examples/electrothermal/coaxial_hfss_icepak.py
+++ b/examples/electrothermal/coaxial_hfss_icepak.py
@@ -365,7 +365,7 @@ my_data.plot(
     y_label="SParameters(dB)",
     title="Scattering Chart",
     snapshot_path=os.path.join(temp_folder.name, "Touchstone_from_matplotlib.jpg"),
-)
+);
 
 # Create a PDF report summarizig results.
 

--- a/examples/electrothermal/coaxial_hfss_icepak.py
+++ b/examples/electrothermal/coaxial_hfss_icepak.py
@@ -365,7 +365,7 @@ my_data.plot(
     y_label="SParameters(dB)",
     title="Scattering Chart",
     snapshot_path=os.path.join(temp_folder.name, "Touchstone_from_matplotlib.jpg"),
-);
+)
 
 # Create a PDF report summarizig results.
 

--- a/examples/high_frequency/antenna/5G_antenna_parametrics.py
+++ b/examples/high_frequency/antenna/5G_antenna_parametrics.py
@@ -281,7 +281,7 @@ h3d.analyze()
 
 trace = h3d.get_traces_for_plot()
 solution = h3d.post.get_solution_data(trace[0])
-solution.plot()
+_ = solution.plot()
 
 # ## Create a 2D far-field report in AEDT
 #

--- a/examples/high_frequency/antenna/5G_antenna_parametrics.py
+++ b/examples/high_frequency/antenna/5G_antenna_parametrics.py
@@ -281,7 +281,7 @@ h3d.analyze()
 
 trace = h3d.get_traces_for_plot()
 solution = h3d.post.get_solution_data(trace[0])
-solution.plot()
+solution.plot();
 
 # ## Create a 2D far-field report in AEDT
 #

--- a/examples/high_frequency/antenna/5G_antenna_parametrics.py
+++ b/examples/high_frequency/antenna/5G_antenna_parametrics.py
@@ -281,7 +281,7 @@ h3d.analyze()
 
 trace = h3d.get_traces_for_plot()
 solution = h3d.post.get_solution_data(trace[0])
-solution.plot();
+solution.plot()
 
 # ## Create a 2D far-field report in AEDT
 #

--- a/examples/high_frequency/antenna/array.py
+++ b/examples/high_frequency/antenna/array.py
@@ -230,7 +230,7 @@ ffdata.plot_cut(
 # Use the array-aware far-field data returned by ``get_antenna_data()`` for the
 # 3D visualization so that all array elements are rendered with the pattern.
 
-is_doc_build = os.getenv("PYAEDT_DOC_GENERATION", "False").lower() in ("true", "1", "t"):
+is_doc_build = os.getenv("PYAEDT_DOC_GENERATION", "False").lower() in ("true", "1", "t")
 p = pv.Plotter(notebook=True, off_screen=is_doc_build)
 ffdata.plot_3d(
     quantity="RealizedGain",

--- a/examples/high_frequency/antenna/array.py
+++ b/examples/high_frequency/antenna/array.py
@@ -17,6 +17,7 @@ import os
 import tempfile
 import time
 
+import pyvista as pv
 from ansys.aedt.core import Hfss
 from ansys.aedt.core.examples.downloads import download_3dcomponent
 from ansys.aedt.core.generic import file_utils
@@ -229,11 +230,14 @@ ffdata.plot_cut(
 # Use the array-aware far-field data returned by ``get_antenna_data()`` for the
 # 3D visualization so that all array elements are rendered with the pattern.
 
-array_farfield_data.plot_3d(
+is_doc_build = os.environ.get("PYAEDT_DOC_GENERATION", "0") == "1"
+p = pv.Plotter(notebook=True, off_screen=is_doc_build)
+ffdata.plot_3d(
     quantity="RealizedGain",
-    output_file=os.path.join(working_directory, "Image.jpg"),
     show=False,
+    pyvista_object=p,
 )
+p.show(jupyter_backend="html")
 
 # ### Clean up
 #

--- a/examples/high_frequency/antenna/array.py
+++ b/examples/high_frequency/antenna/array.py
@@ -230,7 +230,7 @@ ffdata.plot_cut(
 # Use the array-aware far-field data returned by ``get_antenna_data()`` for the
 # 3D visualization so that all array elements are rendered with the pattern.
 
-is_doc_build = os.environ.get("PYAEDT_DOC_GENERATION", "0") == "1"
+is_doc_build = os.getenv("PYAEDT_DOC_GENERATION", "False").lower() in ("true", "1", "t"):
 p = pv.Plotter(notebook=True, off_screen=is_doc_build)
 ffdata.plot_3d(
     quantity="RealizedGain",

--- a/examples/high_frequency/antenna/dipole.py
+++ b/examples/high_frequency/antenna/dipole.py
@@ -243,7 +243,7 @@ xpol.children["Legend"].properties["Show Variation Key"] = False
 # the report in HFSS.
 
 ff_el_data = elevation_ffd_plot.get_solution_data()
-ff_el_data.plot(x_label="Theta", y_label="Gain", is_polar=True);
+ff_el_data.plot(x_label="Theta", y_label="Gain", is_polar=True)
 
 
 # ## Release AEDT

--- a/examples/high_frequency/antenna/dipole.py
+++ b/examples/high_frequency/antenna/dipole.py
@@ -243,7 +243,7 @@ xpol.children["Legend"].properties["Show Variation Key"] = False
 # the report in HFSS.
 
 ff_el_data = elevation_ffd_plot.get_solution_data()
-ff_el_data.plot(x_label="Theta", y_label="Gain", is_polar=True)
+ff_el_data.plot(x_label="Theta", y_label="Gain", is_polar=True);
 
 
 # ## Release AEDT

--- a/examples/high_frequency/antenna/dipole.py
+++ b/examples/high_frequency/antenna/dipole.py
@@ -243,7 +243,7 @@ xpol.children["Legend"].properties["Show Variation Key"] = False
 # the report in HFSS.
 
 ff_el_data = elevation_ffd_plot.get_solution_data()
-ff_el_data.plot(x_label="Theta", y_label="Gain", is_polar=True)
+_ = ff_el_data.plot(x_label="Theta", y_label="Gain", is_polar=True)
 
 
 # ## Release AEDT

--- a/examples/high_frequency/antenna/large_scenarios/city.py
+++ b/examples/high_frequency/antenna/large_scenarios/city.py
@@ -69,7 +69,7 @@ app.modeler.import_from_openstreet_map(
     ansys_home,
     terrain_radius=250,
     road_step=3,
-    plot_before_importing=True,
+    plot_before_importing=False,
     import_in_aedt=True,
 )
 # Reverting back to release on exception.

--- a/examples/high_frequency/antenna/large_scenarios/doppler.py
+++ b/examples/high_frequency/antenna/large_scenarios/doppler.py
@@ -16,6 +16,7 @@ import time
 
 import ansys.aedt.core
 from ansys.aedt.core.examples.downloads import download_file, download_multiparts, unzip
+import matplotlib.pyplot as plt
 
 # -
 
@@ -199,8 +200,19 @@ for frame, data_frame in frames_dict.items():
 
 frtm_plotter = FRTMPlotter(doppler_data_frames)
 frame_number = frtm_plotter.frames[0]
-frtm_plotter.plot_range_doppler(frame=frame_number)
-frtm_plotter.plot_range_angle_map(frame=frame_number, polar=True)
+plotter_rd = frtm_plotter.plot_range_doppler(frame=frame_number, show=False)
+if plotter_rd.fig:
+    plotter_rd.fig.set_constrained_layout(False)
+    plt.figure(plotter_rd.fig.number)
+    plt.show()
+    plt.close(plotter_rd.fig)
+
+plotter_ra = frtm_plotter.plot_range_angle_map(frame=frame_number, polar=True, show=False)
+if plotter_ra.fig:
+    plotter_ra.fig.set_constrained_layout(False)
+    plt.figure(plotter_ra.fig.number)
+    plt.show()
+    plt.close(plotter_ra.fig)
 
 # ## Release AEDT
 #

--- a/examples/high_frequency/antenna/large_scenarios/reflector.py
+++ b/examples/high_frequency/antenna/large_scenarios/reflector.py
@@ -113,7 +113,7 @@ solution = target.post.get_solution_data(
     context="ATK_3D",
     report_category="Far Fields",
 )
-solution.plot()
+_ = solution.plot()
 
 # ## Release AEDT
 #

--- a/examples/high_frequency/antenna/large_scenarios/reflector.py
+++ b/examples/high_frequency/antenna/large_scenarios/reflector.py
@@ -113,7 +113,7 @@ solution = target.post.get_solution_data(
     context="ATK_3D",
     report_category="Far Fields",
 )
-solution.plot();
+solution.plot()
 
 # ## Release AEDT
 #

--- a/examples/high_frequency/antenna/large_scenarios/reflector.py
+++ b/examples/high_frequency/antenna/large_scenarios/reflector.py
@@ -113,7 +113,7 @@ solution = target.post.get_solution_data(
     context="ATK_3D",
     report_category="Far Fields",
 )
-solution.plot()
+solution.plot();
 
 # ## Release AEDT
 #

--- a/examples/high_frequency/antenna/large_scenarios/time_domain.py
+++ b/examples/high_frequency/antenna/large_scenarios/time_domain.py
@@ -10,9 +10,13 @@
 # Perform required imports.
 
 # +
+import base64
 import os
 import tempfile
 import time
+
+from IPython.display import HTML, display
+from IPython.utils import io as ipio
 
 from ansys.aedt.core import Hfss
 from ansys.aedt.core.examples.downloads import download_sbr_time
@@ -81,17 +85,31 @@ frames_list_file = solution_data.ifft_to_file(
 
 # ## Plot scene
 #
-# Plot the scene to create the time plot animation
+# Plot the scene to create the time plot animation and save it to a GIF file.
 
-hfss.post.plot_scene(
-    frames=frames_list_file,
-    gif_path=os.path.join(hfss.working_directory, "animation.gif"),
-    norm_index=15,
-    dy_rng=35,
-    show=False,
-    view="xy",
-    zoom=1,
-)
+gif_file = os.path.join(hfss.working_directory, "animation.gif")
+
+
+with ipio.capture_output():
+    hfss.post.plot_scene(
+        frames=frames_list_file,
+        gif_path=gif_file,
+        norm_index=15,
+        dy_rng=35,
+        show=False,
+        view="xy",
+        zoom=1,
+    )
+
+# ## Display animation
+#
+# nbsphinx does not render ``image/gif`` cell outputs natively.
+# The GIF is embedded as a base64 data URI inside an HTML ``<img>`` tag,
+# which nbsphinx renders correctly in the static HTML documentation.
+
+with open(gif_file, "rb") as f:
+    gif_b64 = base64.b64encode(f.read()).decode()
+display(HTML(f'<img src="data:image/gif;base64,{gif_b64}" width="600"/>'))
 
 # ## Release AEDT
 #

--- a/examples/high_frequency/antenna/large_scenarios/time_domain.py
+++ b/examples/high_frequency/antenna/large_scenarios/time_domain.py
@@ -88,8 +88,6 @@ frames_list_file = solution_data.ifft_to_file(
 # Plot the scene to create the time plot animation and save it to a GIF file.
 
 gif_file = os.path.join(hfss.working_directory, "animation.gif")
-
-
 with ipio.capture_output():
     hfss.post.plot_scene(
         frames=frames_list_file,

--- a/examples/high_frequency/emc/busbar.py
+++ b/examples/high_frequency/emc/busbar.py
@@ -216,7 +216,7 @@ reduced_matrix_2_self_report.edit_x_axis_scaling(linear_scaling=False)
 # Retrieve solution data for processing in Python.
 
 data = q3d.post.get_solution_data(expressions=original_matrix_self, context="Original")
-data.plot()
+data.plot();
 
 # ## Release AEDT
 

--- a/examples/high_frequency/emc/busbar.py
+++ b/examples/high_frequency/emc/busbar.py
@@ -216,7 +216,7 @@ reduced_matrix_2_self_report.edit_x_axis_scaling(linear_scaling=False)
 # Retrieve solution data for processing in Python.
 
 data = q3d.post.get_solution_data(expressions=original_matrix_self, context="Original")
-data.plot();
+data.plot()
 
 # ## Release AEDT
 

--- a/examples/high_frequency/emc/busbar.py
+++ b/examples/high_frequency/emc/busbar.py
@@ -216,7 +216,7 @@ reduced_matrix_2_self_report.edit_x_axis_scaling(linear_scaling=False)
 # Retrieve solution data for processing in Python.
 
 data = q3d.post.get_solution_data(expressions=original_matrix_self, context="Original")
-data.plot()
+_ = data.plot()
 
 # ## Release AEDT
 

--- a/examples/high_frequency/layout/power_integrity/ac_q3d.py
+++ b/examples/high_frequency/layout/power_integrity/ac_q3d.py
@@ -153,10 +153,10 @@ solution = q3d.post.get_solution_data(traces_acl)
 #
 # Plot AC inductance and resistance.
 
-solution.plot()
+_ = solution.plot()
 traces_acr = q3d.post.available_report_quantities(quantities_category="ACR Matrix")
 solution2 = q3d.post.get_solution_data(traces_acr)
-solution2.plot()
+_ = solution2.plot()
 
 # ## Release AEDT
 

--- a/examples/high_frequency/layout/signal_integrity/circuit_transient.py
+++ b/examples/high_frequency/layout/signal_integrity/circuit_transient.py
@@ -106,7 +106,7 @@ report = circuit.post.create_report("V(Vout)", domain="Time")
 if not NG_MODE:
     report.add_cartesian_y_marker(0)
 solutions = circuit.post.get_solution_data(domain="Time")
-solutions.plot("V(Vout)")
+_ = solutions.plot("V(Vout)")
 
 # ## Visualize results
 #
@@ -140,7 +140,7 @@ new_report.time_start = "20ns"
 new_report.time_stop = "100ns"
 new_report.create()
 sol = new_report.get_solution_data()
-sol.plot()
+_ = sol.plot()
 
 # ## Create eye diagram in AEDT
 #

--- a/examples/high_frequency/multiphysics/mri.py
+++ b/examples/high_frequency/multiphysics/mri.py
@@ -22,9 +22,13 @@
 # Perform required imports.
 
 # +
+import base64
 import os.path
 import tempfile
 import time
+
+from IPython.display import HTML, display
+from IPython.utils import io as ipio
 
 from ansys.aedt.core import Hfss, Icepak, Mechanical
 from ansys.aedt.core.examples import downloads
@@ -254,16 +258,27 @@ data = mech.post.get_solution_data(
 )
 data.plot()
 
-mech.post.plot_animated_field(
-    quantity="Temperature",
-    assignment="implant:YZ",
-    plot_type="CutPlane",
-    intrinsics={"Time": "15s"},
-    variation_variable="Time",
-    variations=["15s", "30s"],
-    filter_objects=["implant_box"],
-    show=False,
-)
+gif_file = os.path.join(tempfile.gettempdir(), "mri_animated.gif")
+
+with ipio.capture_output():
+    anim = mech.post.plot_animated_field(
+        quantity="Temperature",
+        assignment="implant:YZ",
+        plot_type="CutPlane",
+        intrinsics={"Time": "15s"},
+        variation_variable="Time",
+        variations=["15s", "30s"],
+        filter_objects=["implant_box"],
+        show=False,
+    )
+    anim.is_notebook = False
+    anim.off_screen = True
+    anim.gif_file = gif_file
+    anim.animate(show=False)
+
+with open(gif_file, "rb") as f:
+    gif_b64 = base64.b64encode(f.read()).decode()
+display(HTML(f'<img src="data:image/gif;base64,{gif_b64}" width="600"/>'))
 # -
 
 # ## Run a new thermal simulation

--- a/examples/high_frequency/multiphysics/mri.py
+++ b/examples/high_frequency/multiphysics/mri.py
@@ -256,7 +256,7 @@ data = mech.post.get_solution_data(
     context="Point1",
     report_category="Fields",
 )
-data.plot()
+_ = data.plot()
 
 gif_file = os.path.join(tempfile.gettempdir(), "mri_animated.gif")
 

--- a/examples/high_frequency/radiofrequency_mmwave/coplanar_waveguide.py
+++ b/examples/high_frequency/radiofrequency_mmwave/coplanar_waveguide.py
@@ -237,7 +237,7 @@ q2d.analyze(cores=NUM_CORES)
 # View the impedance over frequency.
 
 data = q2d.post.get_solution_data(expressions="Z0(signal,signal)", context="Original")
-data.plot();
+_ = data.plot()
 
 # ## Finish
 #

--- a/examples/high_frequency/radiofrequency_mmwave/coplanar_waveguide.py
+++ b/examples/high_frequency/radiofrequency_mmwave/coplanar_waveguide.py
@@ -237,7 +237,7 @@ q2d.analyze(cores=NUM_CORES)
 # View the impedance over frequency.
 
 data = q2d.post.get_solution_data(expressions="Z0(signal,signal)", context="Original")
-data.plot()
+data.plot();
 
 # ## Finish
 #

--- a/examples/high_frequency/radiofrequency_mmwave/spiral.py
+++ b/examples/high_frequency/radiofrequency_mmwave/spiral.py
@@ -210,7 +210,7 @@ hfss.create_output_variable("L", L_formula, solution="setup1 : LastAdaptive")
 # Plot the results using Matplotlib.
 
 data = hfss.post.get_solution_data([L_formula, Q_formula])
-data.plot(curves=[L_formula, Q_formula], formula="re", x_label="Freq", y_label="L and Q");
+_ = data.plot(curves=[L_formula, Q_formula], formula="re", x_label="Freq", y_label="L and Q")
 
 # Export results to a CSV file
 

--- a/examples/high_frequency/radiofrequency_mmwave/spiral.py
+++ b/examples/high_frequency/radiofrequency_mmwave/spiral.py
@@ -210,7 +210,7 @@ hfss.create_output_variable("L", L_formula, solution="setup1 : LastAdaptive")
 # Plot the results using Matplotlib.
 
 data = hfss.post.get_solution_data([L_formula, Q_formula])
-data.plot(curves=[L_formula, Q_formula], formula="re", x_label="Freq", y_label="L and Q")
+data.plot(curves=[L_formula, Q_formula], formula="re", x_label="Freq", y_label="L and Q");
 
 # Export results to a CSV file
 

--- a/examples/high_frequency/radiofrequency_mmwave/stripline.py
+++ b/examples/high_frequency/radiofrequency_mmwave/stripline.py
@@ -227,7 +227,7 @@ plot_sources = matrix.get_sources_for_plot(category="Z0")
 # Get simulation results as a ``SolutionData`` object and plot to a JPG file.
 
 data = q2d.post.get_solution_data(expressions=plot_sources, context=matrix.name)
-data.plot(snapshot_path=os.path.join(temp_folder.name, "plot.jpg"))
+data.plot(snapshot_path=os.path.join(temp_folder.name, "plot.jpg"));
 
 # -
 

--- a/examples/low_frequency/general/control_program.py
+++ b/examples/low_frequency/general/control_program.py
@@ -85,7 +85,7 @@ m2d.analyze(setup=setup.name, cores=NUM_CORES, use_auto_settings=False)
 # Display the simulation results.
 
 sols = m2d.post.get_solution_data(expressions="FluxLinkage(Winding1)", variations={"Time": ["All"]}, primary_sweep_variable="Time", domain="Sweep")
-sols.plot()
+sols.plot();
 
 # ## Release AEDT
 

--- a/examples/low_frequency/general/control_program.py
+++ b/examples/low_frequency/general/control_program.py
@@ -85,7 +85,7 @@ m2d.analyze(setup=setup.name, cores=NUM_CORES, use_auto_settings=False)
 # Display the simulation results.
 
 sols = m2d.post.get_solution_data(expressions="FluxLinkage(Winding1)", variations={"Time": ["All"]}, primary_sweep_variable="Time", domain="Sweep")
-sols.plot();
+_ = sols.plot()
 
 # ## Release AEDT
 

--- a/examples/low_frequency/general/resistance.py
+++ b/examples/low_frequency/general/resistance.py
@@ -10,9 +10,13 @@
 # Perform required imports.
 
 # +
+import base64
 import os.path
 import tempfile
 import time
+
+from IPython.display import HTML, display
+from IPython.utils import io as ipio
 
 import ansys.aedt.core
 from ansys.aedt.core.examples.downloads import download_file
@@ -224,25 +228,35 @@ py_vista_plot.plot(os.path.join(temp_folder.name, "mag_E.jpg"))
 
 # ## Plot field animation
 #
-# Plot current density verus the material index.
+# Plot current density versus the material index and save it to a GIF file.
 
-animated_plot = m2d.post.plot_animated_field(
-    quantity="Mag_J",
-    assignment=conductor_surface,
-    export_path=temp_folder.name,
-    variation_variable="MaterialIndex",
-    variations=[0, 1, 2, 3],
-    show=False,
-    export_gif=False,
-    log_scale=True,
-)
-animated_plot.isometric_view = False
-animated_plot.camera_position = [0, 0, 7]
-animated_plot.focal_point = [0, 0, 0]
-animated_plot.roll_angle = 0
-animated_plot.elevation_angle = 0
-animated_plot.azimuth_angle = 0
-animated_plot.animate(show=False)
+gif_file = os.path.join(temp_folder.name, "animated_field.gif")
+
+with ipio.capture_output():
+    animated_plot = m2d.post.plot_animated_field(
+        quantity="Mag_J",
+        assignment=conductor_surface,
+        export_path=temp_folder.name,
+        variation_variable="MaterialIndex",
+        variations=[0, 1, 2, 3],
+        show=False,
+        export_gif=False,
+        log_scale=True,
+    )
+    animated_plot.isometric_view = False
+    animated_plot.camera_position = [0, 0, 7]
+    animated_plot.focal_point = [0, 0, 0]
+    animated_plot.roll_angle = 0
+    animated_plot.elevation_angle = 0
+    animated_plot.azimuth_angle = 0
+    animated_plot.is_notebook = False
+    animated_plot.off_screen = True
+    animated_plot.gif_file = gif_file
+    animated_plot.animate(show=False)
+
+with open(gif_file, "rb") as f:
+    gif_b64 = base64.b64encode(f.read()).decode()
+display(HTML(f'<img src="data:image/gif;base64,{gif_b64}" width="600"/>'))
 
 # ## Export model picture
 

--- a/examples/low_frequency/general/resistance.py
+++ b/examples/low_frequency/general/resistance.py
@@ -230,6 +230,7 @@ py_vista_plot.plot(os.path.join(temp_folder.name, "mag_E.jpg"))
 #
 # Plot current density versus the material index and save it to a GIF file.
 
+# +
 gif_file = os.path.join(temp_folder.name, "animated_field.gif")
 
 with ipio.capture_output():
@@ -257,6 +258,7 @@ with ipio.capture_output():
 with open(gif_file, "rb") as f:
     gif_b64 = base64.b64encode(f.read()).decode()
 display(HTML(f'<img src="data:image/gif;base64,{gif_b64}" width="600"/>'))
+# -
 
 # ## Export model picture
 

--- a/examples/low_frequency/general/resistance.py
+++ b/examples/low_frequency/general/resistance.py
@@ -191,7 +191,7 @@ data = report.get_solution_data()
 resistance = data.get_expression_data(formula="magnitude")[1]
 material_index = data.primary_sweep_values
 data.primary_sweep = "MaterialIndex"
-data.plot(snapshot_path=os.path.join(temp_folder.name, "M2D_DCConduction.jpg"))
+_ = data.plot(snapshot_path=os.path.join(temp_folder.name, "M2D_DCConduction.jpg"))
 
 # ## Create material index versus resistance table
 #

--- a/examples/low_frequency/general/twin_builder/rc_circuit.py
+++ b/examples/low_frequency/general/twin_builder/rc_circuit.py
@@ -92,7 +92,7 @@ E_Value = "E1.V"
 C_Value = "C1.V"
 
 x = tb.post.get_solution_data([E_Value, C_Value], "TR", "Time")
-x.plot([E_Value, C_Value], x_label="Time", y_label="Capacitor Voltage vs Input Pulse");
+_ = x.plot([E_Value, C_Value], x_label="Time", y_label="Capacitor Voltage vs Input Pulse")
 
 # ## Release AEDT
 #

--- a/examples/low_frequency/general/twin_builder/rc_circuit.py
+++ b/examples/low_frequency/general/twin_builder/rc_circuit.py
@@ -92,7 +92,7 @@ E_Value = "E1.V"
 C_Value = "C1.V"
 
 x = tb.post.get_solution_data([E_Value, C_Value], "TR", "Time")
-x.plot([E_Value, C_Value], x_label="Time", y_label="Capacitor Voltage vs Input Pulse")
+x.plot([E_Value, C_Value], x_label="Time", y_label="Capacitor Voltage vs Input Pulse");
 
 # ## Release AEDT
 #

--- a/examples/low_frequency/magnetic/transient_winding.py
+++ b/examples/low_frequency/magnetic/transient_winding.py
@@ -147,7 +147,7 @@ display(HTML(f'<img src="data:image/gif;base64,{gif_b64}" width="600"/>'))
 # Generate the same plot outside AEDT.
 
 solutions = m2d.post.get_solution_data(expressions="InputCurrent(PHA)", primary_sweep_variable="Time", domain="Sweep")
-solutions.plot();
+_ = solutions.plot()
 
 # ## Release AEDT
 

--- a/examples/low_frequency/magnetic/transient_winding.py
+++ b/examples/low_frequency/magnetic/transient_winding.py
@@ -23,9 +23,13 @@
 # Perform required imports.
 
 # +
+import base64
 import os
 import tempfile
 import time
+
+from IPython.display import HTML, display
+from IPython.utils import io as ipio
 
 import ansys.aedt.core
 
@@ -109,26 +113,33 @@ face_lists += rect2.faces
 timesteps = [str(i * 2e-4) + "s" for i in range(11)]
 id_list = [f.id for f in face_lists]
 
-gif = m2d.post.plot_animated_field(
-    quantity="Mag_B",
-    assignment=id_list,
-    plot_type="Surface",
-    intrinsics={"Time": "0s"},
-    variation_variable="Time",
-    variations=timesteps,
-    show=False,
-    export_gif=False,
-)
-gif.isometric_view = False
-gif.camera_position = [15, 15, 80]
-gif.focal_point = [15, 15, 0]
-gif.roll_angle = 0
-gif.elevation_angle = 0
-gif.azimuth_angle = 0
+gif_file = os.path.join(temp_folder.name, "animated_field.gif")
 
-# Set off_screen to False to visualize the animation.
-# gif.off_screen = False
-gif.animate(show=False)
+with ipio.capture_output():
+    gif = m2d.post.plot_animated_field(
+        quantity="Mag_B",
+        assignment=id_list,
+        plot_type="Surface",
+        intrinsics={"Time": "0s"},
+        variation_variable="Time",
+        variations=timesteps,
+        show=False,
+        export_gif=False,
+    )
+    gif.isometric_view = False
+    gif.camera_position = [15, 15, 80]
+    gif.focal_point = [15, 15, 0]
+    gif.roll_angle = 0
+    gif.elevation_angle = 0
+    gif.azimuth_angle = 0
+    gif.is_notebook = False
+    gif.off_screen = True
+    gif.gif_file = gif_file
+    gif.animate(show=False)
+
+with open(gif_file, "rb") as f:
+    gif_b64 = base64.b64encode(f.read()).decode()
+display(HTML(f'<img src="data:image/gif;base64,{gif_b64}" width="600"/>'))
 # -
 
 # ## Generate plot outside of AEDT

--- a/examples/low_frequency/magnetic/transient_winding.py
+++ b/examples/low_frequency/magnetic/transient_winding.py
@@ -147,7 +147,7 @@ display(HTML(f'<img src="data:image/gif;base64,{gif_b64}" width="600"/>'))
 # Generate the same plot outside AEDT.
 
 solutions = m2d.post.get_solution_data(expressions="InputCurrent(PHA)", primary_sweep_variable="Time", domain="Sweep")
-solutions.plot()
+solutions.plot();
 
 # ## Release AEDT
 

--- a/examples/low_frequency/team_problem/bath_plate.py
+++ b/examples/low_frequency/team_problem/bath_plate.py
@@ -262,7 +262,7 @@ solutions = m3d.post.get_solution_data(
 # ### Set up sweep value and plot solution
 
 solutions.active_variation["Coil_Position"] = solutions.variations[0]["Coil_Position"]
-solutions.plot();
+_ = solutions.plot()
 
 # ### Change sweep value and plot solution
 #
@@ -270,7 +270,7 @@ solutions.plot();
 # Uncomment to show plots.
 
 solutions.active_variation["Coil_Position"] = solutions.variations[1]["Coil_Position"]
-solutions.plot();
+_ = solutions.plot()
 
 # ### Plot induced current density on surface of ladder plate
 #

--- a/examples/low_frequency/team_problem/bath_plate.py
+++ b/examples/low_frequency/team_problem/bath_plate.py
@@ -262,7 +262,7 @@ solutions = m3d.post.get_solution_data(
 # ### Set up sweep value and plot solution
 
 solutions.active_variation["Coil_Position"] = solutions.variations[0]["Coil_Position"]
-solutions.plot()
+solutions.plot();
 
 # ### Change sweep value and plot solution
 #
@@ -270,7 +270,7 @@ solutions.plot()
 # Uncomment to show plots.
 
 solutions.active_variation["Coil_Position"] = solutions.variations[1]["Coil_Position"]
-solutions.plot()
+solutions.plot();
 
 # ### Plot induced current density on surface of ladder plate
 #


### PR DESCRIPTION
## Description

This pull request updates several example scripts to improve the generation and display of animated GIFs for field visualizations, particularly for documentation builds and Jupyter rendering. It also standardizes plotting calls and improves notebook compatibility. The most significant changes are grouped below.

**Animated GIF Generation and Display Enhancements:**

* Added code to generate animated GIFs for field visualizations in several examples (`resistance.py`, `time_domain.py`, `transient_winding.py`, `coaxial_hfss_icepak.py`, `mri.py`), capturing the output, saving the animation to a GIF file, and embedding it as a base64-encoded HTML `<img>` tag for better documentation and notebook support.

* Updated import statements in affected files to include `base64`, `IPython.display`, and `IPython.utils.io` as needed for GIF embedding.

**Documentation Build and Example Selection:**

* Modified the Sphinx documentation build configuration to skip new example files containing animations, ensuring LaTeX builds do not attempt to process these GIF-generating scripts.

**Plotting and Visualization Improvements:**

* Standardized the use of semicolons after `plot()` calls across many examples to suppress unwanted output in Jupyter notebooks. (F281, F243, F216, F237, F210, F227, F85, F92, F262)
* Updated the 3D array antenna example to use a `pyvista.Plotter` object with notebook and off-screen rendering settings based on documentation build environment, and to display the plot inline.

**Other Minor Enhancements:**

* Added missing imports (e.g., `matplotlib.pyplot as plt`) and improved plot display logic in the Doppler scenario example for better figure handling in notebook and documentation contexts.

These changes collectively enhance the user experience when running and viewing the examples, especially in Jupyter and static documentation environments.

## Issue linked
None

## Checklist
Please complete the following checklist before submitting your pull request:
- [ ] I have followed the example template and guide lines to add/update an example.
- [ ] I have tested the example locally and verified that it is working with the latest version of AEDT.
- [ ] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
