### PR TITLE
CHORE: Remove the ansys `add-license-headers` hook from the `.pre-commit-config.yaml` file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,10 +42,3 @@ repos:
   hooks:
     - id: debug-statements
     - id: trailing-whitespace
-
-- repo: https://github.com/ansys/pre-commit-hooks
-  rev: 55c5b6a5439abd847613579c6924da750e8b78b2  # frozen: v0.8.0
-  hooks:
-  - id: add-license-headers
-    args:
-    - --start_year=2024


### PR DESCRIPTION
Following a suggestion made by @gmalinve, I am opening this PR to suggest we remove the ansys `add-license-headers` hook from the `.pre-commit-config.yaml` file of the project.

The motivation is that adding the license header to all example scripts would clutter them, as the license would then appear on every page of the online docs (since Python scripts are converted into notebooks during the doc build process, with commented lines appearing as plain text surrounding the code cells). 

The hook was added a few months ago via #567 (PR opened by the pyansys-automation bot), yet license headers have still not been introduced into the examples since. 
This means that the hook is not currently being enforced.. and same goes for all the others if I'm not mistaken, as the pre-commit-ci bot does not seem to be active on `pyaedt-examples` (we might want to fix this). 
Another problem currently is that contributors using `pre-commit` locally as recommended have to bypass the checks to avoid triggering the automatic addition of license headers to every file in the project.
Finally, if this hook is removed, this must be propagated to the automation repository to prevent the bot from immediately reopening a PR like #567 to reinstate it. 

@SMoraisAnsys, could you share your thoughts on this as you merged #567? 
I am skeptical about whether it is fine to simply opt out of this hook for this project, but it seems to be the pragmatic approach given the current situation. 
Also, should pre-commit-ci be enabled for `pyaedt-examples`?